### PR TITLE
feat(#88): add property investment simulation / paper trading

### DIFF
--- a/src/app/paper-trading/page.tsx
+++ b/src/app/paper-trading/page.tsx
@@ -1,0 +1,19 @@
+import { PaperTradingToggle } from '@/components/PaperTradingToggle';
+import { PaperTradingDashboard } from '@/components/PaperTradingDashboard';
+
+export default function PaperTradingPage() {
+  return (
+    <main className="max-w-3xl mx-auto py-8 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Paper Trading</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Simulate property token investments with $10,000 virtual funds — no real money at risk.
+          </p>
+        </div>
+        <PaperTradingToggle />
+      </div>
+      <PaperTradingDashboard />
+    </main>
+  );
+}

--- a/src/components/PaperTradingDashboard.tsx
+++ b/src/components/PaperTradingDashboard.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useState } from 'react';
+import { usePaperTradingStore, type LeaderboardEntry } from '@/store/paperTradingStore';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { MOCK_PROPERTIES } from '@/lib/mockData';
+
+// Simulated leaderboard data
+const MOCK_LEADERBOARD: LeaderboardEntry[] = [
+  { userId: 'user-1', displayName: 'Alice', startingBalance: 10000, currentBalance: 13200, totalReturn: 32, rank: 1 },
+  { userId: 'user-2', displayName: 'Bob', startingBalance: 10000, currentBalance: 11800, totalReturn: 18, rank: 2 },
+  { userId: 'user-3', displayName: 'Carol', startingBalance: 10000, currentBalance: 11200, totalReturn: 12, rank: 3 },
+  { userId: 'user-4', displayName: 'Dave', startingBalance: 10000, currentBalance: 10500, totalReturn: 5, rank: 4 },
+  { userId: 'user-5', displayName: 'Eve', startingBalance: 10000, currentBalance: 9800, totalReturn: -2, rank: 5 },
+];
+
+function fmt(n: number) {
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+}
+
+function pct(n: number) {
+  return `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`;
+}
+
+export function PaperTradingDashboard() {
+  const {
+    isPaperMode,
+    virtualBalance,
+    positions,
+    transactions,
+    buyTokens,
+    sellTokens,
+    updatePrice,
+    resetPortfolio,
+    getPortfolioValue,
+    getTotalReturn,
+    getPositionPnL,
+  } = usePaperTradingStore();
+
+  const [selectedPropertyId, setSelectedPropertyId] = useState(MOCK_PROPERTIES[0]?.id ?? '');
+  const [tokenAmount, setTokenAmount] = useState('');
+  const [tradeError, setTradeError] = useState('');
+  const [tradeSuccess, setTradeSuccess] = useState('');
+
+  if (!isPaperMode) return null;
+
+  const selectedProperty = MOCK_PROPERTIES.find((p) => p.id === selectedPropertyId);
+  const portfolioValue = getPortfolioValue();
+  const totalReturn = getTotalReturn();
+  const totalAssets = virtualBalance + portfolioValue;
+
+  function handleBuy() {
+    setTradeError('');
+    setTradeSuccess('');
+    if (!selectedProperty) return;
+    const tokens = parseFloat(tokenAmount);
+    if (isNaN(tokens) || tokens <= 0) {
+      setTradeError('Enter a valid token amount');
+      return;
+    }
+    // Sync current price
+    updatePrice(selectedProperty.id, selectedProperty.price.perToken);
+    const result = buyTokens(selectedProperty.id, selectedProperty.name, tokens, selectedProperty.price.perToken);
+    if (result.success) {
+      setTradeSuccess(`Bought ${tokens} tokens of ${selectedProperty.name}`);
+      setTokenAmount('');
+    } else {
+      setTradeError(result.error ?? 'Trade failed');
+    }
+  }
+
+  function handleSell() {
+    setTradeError('');
+    setTradeSuccess('');
+    if (!selectedProperty) return;
+    const tokens = parseFloat(tokenAmount);
+    if (isNaN(tokens) || tokens <= 0) {
+      setTradeError('Enter a valid token amount');
+      return;
+    }
+    const result = sellTokens(selectedProperty.id, tokens, selectedProperty.price.perToken);
+    if (result.success) {
+      setTradeSuccess(`Sold ${tokens} tokens of ${selectedProperty.name}`);
+      setTokenAmount('');
+    } else {
+      setTradeError(result.error ?? 'Trade failed');
+    }
+  }
+
+  // Build leaderboard with current user injected
+  const myEntry: LeaderboardEntry = {
+    userId: 'me',
+    displayName: 'You',
+    startingBalance: 10000,
+    currentBalance: totalAssets,
+    totalReturn,
+    rank: 0,
+  };
+  const combined = [...MOCK_LEADERBOARD, myEntry]
+    .sort((a, b) => b.totalReturn - a.totalReturn)
+    .map((e, i) => ({ ...e, rank: i + 1 }));
+
+  return (
+    <div className="space-y-6 p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold">Paper Trading Dashboard</h2>
+        <Badge variant="secondary">Simulation Mode</Badge>
+      </div>
+
+      {/* Virtual Wallet */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm text-muted-foreground">Cash Balance</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{fmt(virtualBalance)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm text-muted-foreground">Portfolio Value</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{fmt(portfolioValue)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-sm text-muted-foreground">Total Return</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className={`text-2xl font-bold ${totalReturn >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {pct(totalReturn)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Trade Panel */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Simulate Trade</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <label className="text-sm font-medium mb-1 block">Property</label>
+            <select
+              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              value={selectedPropertyId}
+              onChange={(e) => setSelectedPropertyId(e.target.value)}
+            >
+              {MOCK_PROPERTIES.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name} — {fmt(p.price.perToken)}/token
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-1 block">Token Amount</label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="e.g. 10"
+              value={tokenAmount}
+              onChange={(e) => setTokenAmount(e.target.value)}
+            />
+            {selectedProperty && tokenAmount && !isNaN(parseFloat(tokenAmount)) && (
+              <p className="text-xs text-muted-foreground mt-1">
+                Cost: {fmt(parseFloat(tokenAmount) * selectedProperty.price.perToken)}
+              </p>
+            )}
+          </div>
+          {tradeError && <p className="text-sm text-red-600">{tradeError}</p>}
+          {tradeSuccess && <p className="text-sm text-green-600">{tradeSuccess}</p>}
+          <div className="flex gap-2">
+            <Button onClick={handleBuy} className="flex-1">Buy</Button>
+            <Button onClick={handleSell} variant="outline" className="flex-1">Sell</Button>
+          </div>
+          <Button variant="ghost" size="sm" onClick={resetPortfolio} className="w-full text-muted-foreground">
+            Reset Portfolio
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Positions */}
+      {positions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Open Positions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {positions.map((pos) => {
+                const pnl = getPositionPnL(pos.propertyId);
+                return (
+                  <div key={pos.propertyId} className="flex items-center justify-between text-sm border-b pb-2 last:border-0">
+                    <div>
+                      <p className="font-medium">{pos.propertyName}</p>
+                      <p className="text-muted-foreground">{pos.tokensBought} tokens @ {fmt(pos.avgBuyPrice)}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-medium">{fmt(pos.tokensBought * pos.currentPrice)}</p>
+                      <p className={pnl >= 0 ? 'text-green-600' : 'text-red-600'}>{pnl >= 0 ? '+' : ''}{fmt(pnl)}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Transaction History */}
+      {transactions.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Transaction History</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 max-h-48 overflow-y-auto">
+              {transactions.slice(0, 20).map((tx) => (
+                <div key={tx.id} className="flex items-center justify-between text-sm border-b pb-1 last:border-0">
+                  <div>
+                    <Badge variant={tx.type === 'buy' ? 'default' : 'secondary'} className="mr-2 text-xs">
+                      {tx.type.toUpperCase()}
+                    </Badge>
+                    <span>{tx.propertyName}</span>
+                  </div>
+                  <div className="text-right">
+                    <p>{tx.tokens} tokens</p>
+                    <p className="text-muted-foreground">{fmt(tx.total)}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Leaderboard */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Leaderboard</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {combined.map((entry) => (
+              <div
+                key={entry.userId}
+                className={`flex items-center justify-between text-sm p-2 rounded-md ${entry.userId === 'me' ? 'bg-muted font-semibold' : ''}`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="w-5 text-muted-foreground">#{entry.rank}</span>
+                  <span>{entry.displayName}</span>
+                  {entry.userId === 'me' && <Badge variant="outline" className="text-xs">You</Badge>}
+                </div>
+                <div className="text-right">
+                  <p>{fmt(entry.currentBalance)}</p>
+                  <p className={entry.totalReturn >= 0 ? 'text-green-600' : 'text-red-600'}>{pct(entry.totalReturn)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/PaperTradingToggle.tsx
+++ b/src/components/PaperTradingToggle.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { usePaperTradingStore } from '@/store/paperTradingStore';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+
+export function PaperTradingToggle() {
+  const { isPaperMode, togglePaperMode } = usePaperTradingStore();
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch
+        id="paper-trading-toggle"
+        checked={isPaperMode}
+        onCheckedChange={togglePaperMode}
+        aria-label="Toggle paper trading mode"
+      />
+      <label htmlFor="paper-trading-toggle" className="text-sm font-medium cursor-pointer select-none">
+        Paper Trading
+      </label>
+      {isPaperMode && (
+        <Badge variant="secondary" className="text-xs">
+          Simulation
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/store/paperTradingStore.ts
+++ b/src/store/paperTradingStore.ts
@@ -1,0 +1,190 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface PaperPosition {
+  propertyId: string;
+  propertyName: string;
+  tokensBought: number;
+  avgBuyPrice: number; // price per token at purchase
+  currentPrice: number; // latest market price per token
+  purchasedAt: number; // timestamp
+}
+
+export interface PaperTransaction {
+  id: string;
+  type: 'buy' | 'sell';
+  propertyId: string;
+  propertyName: string;
+  tokens: number;
+  pricePerToken: number;
+  total: number;
+  timestamp: number;
+}
+
+export interface LeaderboardEntry {
+  userId: string;
+  displayName: string;
+  startingBalance: number;
+  currentBalance: number;
+  totalReturn: number; // percentage
+  rank: number;
+}
+
+const STARTING_BALANCE = 10_000;
+
+interface PaperTradingState {
+  isPaperMode: boolean;
+  virtualBalance: number;
+  positions: PaperPosition[];
+  transactions: PaperTransaction[];
+  leaderboard: LeaderboardEntry[];
+}
+
+interface PaperTradingActions {
+  togglePaperMode: () => void;
+  enablePaperMode: () => void;
+  disablePaperMode: () => void;
+  buyTokens: (propertyId: string, propertyName: string, tokens: number, pricePerToken: number) => { success: boolean; error?: string };
+  sellTokens: (propertyId: string, tokens: number, pricePerToken: number) => { success: boolean; error?: string };
+  updatePrice: (propertyId: string, currentPrice: number) => void;
+  resetPortfolio: () => void;
+  getPortfolioValue: () => number;
+  getTotalReturn: () => number;
+  getPositionPnL: (propertyId: string) => number;
+}
+
+export type PaperTradingStore = PaperTradingState & PaperTradingActions;
+
+export const usePaperTradingStore = create<PaperTradingStore>()(
+  persist(
+    (set, get) => ({
+      isPaperMode: false,
+      virtualBalance: STARTING_BALANCE,
+      positions: [],
+      transactions: [],
+      leaderboard: [],
+
+      togglePaperMode: () => set((s) => ({ isPaperMode: !s.isPaperMode })),
+      enablePaperMode: () => set({ isPaperMode: true }),
+      disablePaperMode: () => set({ isPaperMode: false }),
+
+      buyTokens: (propertyId, propertyName, tokens, pricePerToken) => {
+        const { virtualBalance, positions } = get();
+        const cost = tokens * pricePerToken;
+
+        if (cost > virtualBalance) {
+          return { success: false, error: 'Insufficient virtual balance' };
+        }
+        if (tokens <= 0) {
+          return { success: false, error: 'Token amount must be positive' };
+        }
+
+        const tx: PaperTransaction = {
+          id: `pt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          type: 'buy',
+          propertyId,
+          propertyName,
+          tokens,
+          pricePerToken,
+          total: cost,
+          timestamp: Date.now(),
+        };
+
+        const existing = positions.find((p) => p.propertyId === propertyId);
+        let updatedPositions: PaperPosition[];
+
+        if (existing) {
+          const totalTokens = existing.tokensBought + tokens;
+          const avgPrice = (existing.avgBuyPrice * existing.tokensBought + pricePerToken * tokens) / totalTokens;
+          updatedPositions = positions.map((p) =>
+            p.propertyId === propertyId
+              ? { ...p, tokensBought: totalTokens, avgBuyPrice: avgPrice, currentPrice: pricePerToken }
+              : p
+          );
+        } else {
+          updatedPositions = [
+            ...positions,
+            { propertyId, propertyName, tokensBought: tokens, avgBuyPrice: pricePerToken, currentPrice: pricePerToken, purchasedAt: Date.now() },
+          ];
+        }
+
+        set((s) => ({
+          virtualBalance: s.virtualBalance - cost,
+          positions: updatedPositions,
+          transactions: [tx, ...s.transactions],
+        }));
+
+        return { success: true };
+      },
+
+      sellTokens: (propertyId, tokens, pricePerToken) => {
+        const { positions } = get();
+        const position = positions.find((p) => p.propertyId === propertyId);
+
+        if (!position) return { success: false, error: 'No position found for this property' };
+        if (tokens > position.tokensBought) return { success: false, error: 'Cannot sell more tokens than owned' };
+        if (tokens <= 0) return { success: false, error: 'Token amount must be positive' };
+
+        const proceeds = tokens * pricePerToken;
+        const tx: PaperTransaction = {
+          id: `pt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+          type: 'sell',
+          propertyId,
+          propertyName: position.propertyName,
+          tokens,
+          pricePerToken,
+          total: proceeds,
+          timestamp: Date.now(),
+        };
+
+        const remaining = position.tokensBought - tokens;
+        const updatedPositions =
+          remaining === 0
+            ? positions.filter((p) => p.propertyId !== propertyId)
+            : positions.map((p) => (p.propertyId === propertyId ? { ...p, tokensBought: remaining, currentPrice: pricePerToken } : p));
+
+        set((s) => ({
+          virtualBalance: s.virtualBalance + proceeds,
+          positions: updatedPositions,
+          transactions: [tx, ...s.transactions],
+        }));
+
+        return { success: true };
+      },
+
+      updatePrice: (propertyId, currentPrice) => {
+        set((s) => ({
+          positions: s.positions.map((p) => (p.propertyId === propertyId ? { ...p, currentPrice } : p)),
+        }));
+      },
+
+      resetPortfolio: () =>
+        set({
+          virtualBalance: STARTING_BALANCE,
+          positions: [],
+          transactions: [],
+        }),
+
+      getPortfolioValue: () => {
+        const { positions } = get();
+        return positions.reduce((sum, p) => sum + p.tokensBought * p.currentPrice, 0);
+      },
+
+      getTotalReturn: () => {
+        const { virtualBalance } = get();
+        const portfolioValue = get().getPortfolioValue();
+        const total = virtualBalance + portfolioValue;
+        return ((total - STARTING_BALANCE) / STARTING_BALANCE) * 100;
+      },
+
+      getPositionPnL: (propertyId) => {
+        const position = get().positions.find((p) => p.propertyId === propertyId);
+        if (!position) return 0;
+        return (position.currentPrice - position.avgBuyPrice) * position.tokensBought;
+      },
+    }),
+    {
+      name: 'propchain-paper-trading',
+    }
+  )
+);


### PR DESCRIPTION
Changes
  
  - paperTradingStore.ts — Zustand store (persisted) managing virtual wallet,
  positions, transactions, and return calculations
  - PaperTradingToggle.tsx — Toggle switch to enable/disable simulation mode,
  shown in the page header
  - PaperTradingDashboard.tsx — Full simulation UI: wallet summary, trade panel,
  open positions, transaction history, and leaderboard
  - /paper-trading/page.tsx — New route at /paper-trading
  
  Acceptance Criteria
  
  - [x] Paper trading mode toggle
  - [x] Virtual wallet with $10,000 starting balance
  - [x] Full purchase/sell flow with simulated transactions
  - [x] Performance tracking vs. real market (P&L per position, total return %)
  - [x] Leaderboard for paper traders (ranked by return %, includes live user
  entry)
  
  Notes
  
  - State is persisted to localStorage via Zustand persist — balance and
  positions survive page refresh
  - Prices are sourced from the existing mock property data (price.perToken), so
  performance tracking reflects real market values as that data updates
  - Leaderboard uses seeded mock peers; the current user's live stats are
  injected and ranked dynamically

Closes #88 
