### PR TITLE
fix: dark mode, network switcher, wallet button, mobile layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { ErrorCategory, ErrorSeverity } from "@/types/errors";
 import { logger } from "@/utils/logger";
 import { WalletConnector } from "@/components/WalletConnector";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import {
   ChainAware,
   ChainSpecific,
@@ -116,6 +117,7 @@ function HomeContent() {
               </h1>
             </div>
             <div className="flex items-center gap-3">
+              <ThemeSwitcher />
               <LanguageSwitcher />
               <WalletConnector />
             </div>
@@ -136,7 +138,6 @@ function HomeContent() {
                 <p className="text-gray-600 dark:text-gray-300 mb-6">
                   {t("app.subtitle")}
                 </p>
-                <WalletConnector />
               </div>
             </div>
           }

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -23,6 +23,7 @@ export const NetworkSwitcher: React.FC = () => {
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={isSwitchingNetwork}
+        data-testid="network-switcher"
         className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
       >
         <div

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -48,44 +48,44 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({
         />
         
         {/* Badges */}
-        <div className="absolute top-3 left-3 flex flex-col gap-2">
+        <div className="absolute top-2 left-2 sm:top-3 sm:left-3 flex flex-col gap-1 sm:gap-2">
           {property.featured && (
-            <span className="bg-yellow-500 text-white text-xs font-semibold px-2 py-1 rounded">
+            <span className="bg-yellow-500 text-white text-xs font-semibold px-2 py-0.5 sm:py-1 rounded text-xs">
               ⭐ Featured
             </span>
           )}
           {property.verified && (
-            <span className="bg-green-500 text-white text-xs font-semibold px-2 py-1 rounded flex items-center gap-1">
+            <span className="bg-green-500 text-white text-xs font-semibold px-2 py-0.5 sm:py-1 rounded flex items-center gap-1">
               ✓ Verified
             </span>
           )}
         </div>
 
         {/* ROI Badge */}
-        <div className="absolute top-3 right-3">
-          <div className="bg-blue-600 text-white text-sm font-bold px-3 py-1.5 rounded-lg shadow-lg">
+        <div className="absolute top-2 right-2 sm:top-3 sm:right-3">
+          <div className="bg-blue-600 text-white text-xs sm:text-sm font-bold px-2 py-0.5 sm:px-3 sm:py-1.5 rounded-lg shadow-lg">
             {formatROI(property.metrics.roi)} ROI
           </div>
         </div>
 
         {/* Blockchain Badge */}
-        <div className="absolute bottom-3 left-3">
+        <div className="absolute bottom-2 left-2 sm:bottom-3 sm:left-3">
           <div
-            className="text-white text-xs font-semibold px-2 py-1 rounded flex items-center gap-1"
+            className="text-white text-xs font-semibold px-2 py-0.5 sm:py-1 rounded flex items-center gap-1"
             style={{ backgroundColor: getBlockchainColor(property.blockchain) }}
           >
-            <div className="w-2 h-2 rounded-full bg-white" />
-            {BLOCKCHAIN_LABELS[property.blockchain]}
+            <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full bg-white" />
+            <span className="truncate max-w-[80px] sm:max-w-none">{BLOCKCHAIN_LABELS[property.blockchain]}</span>
           </div>
         </div>
       </div>
 
       {/* Content */}
-      <div className={`p-5 flex flex-col ${isListView ? 'flex-1' : ''}`}>
+      <div className={`p-3 sm:p-5 flex flex-col ${isListView ? 'flex-1' : ''}`}>
         {/* Property Type */}
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-xl">{getPropertyTypeIcon(property.propertyType)}</span>
-          <span className="text-sm text-gray-600 dark:text-gray-400">
+        <div className="flex items-center gap-2 mb-2 flex-wrap">
+          <span className="text-lg sm:text-xl">{getPropertyTypeIcon(property.propertyType)}</span>
+          <span className="text-xs sm:text-sm text-gray-600 dark:text-gray-400">
             {PROPERTY_TYPE_LABELS[property.propertyType]}
           </span>
           {developer && (
@@ -101,17 +101,17 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({
         </div>
 
         {/* Title */}
-        <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-1">
+        <h3 className="text-base sm:text-lg font-bold text-gray-900 dark:text-white mb-1 sm:mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2">
           {property.name}
         </h3>
 
         {/* Location */}
-        <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 mb-3">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="flex items-start gap-1 text-xs sm:text-sm text-gray-600 dark:text-gray-400 mb-2 sm:mb-3">
+          <svg className="w-3 h-3 sm:w-4 sm:h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <span className="line-clamp-1">
+          <span className="line-clamp-2">
             {property.location.city}, {property.location.state}
           </span>
         </div>
@@ -152,41 +152,42 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({
         )}
 
         {/* Token Info */}
-        <div className="flex items-center justify-between mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
-          <div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Available Tokens</p>
-            <p className="text-sm font-semibold text-gray-900 dark:text-white">
+        <div className="flex items-center justify-between mb-3 sm:mb-4 p-2 sm:p-3 bg-gray-50 dark:bg-gray-700 rounded-lg gap-2">
+          <div className="min-w-0">
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">Available Tokens</p>
+            <p className="text-xs sm:text-sm font-semibold text-gray-900 dark:text-white truncate">
               {property.tokenInfo.available.toLocaleString()} / {property.tokenInfo.totalSupply.toLocaleString()}
             </p>
           </div>
-          <div className="text-right">
-            <p className="text-xs text-gray-500 dark:text-gray-400">Per Token</p>
-            <p className="text-sm font-semibold text-gray-900 dark:text-white">
+          <div className="text-right min-w-0">
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">Per Token</p>
+            <p className="text-xs sm:text-sm font-semibold text-gray-900 dark:text-white truncate">
               {formatPrice(property.price.perToken)}
             </p>
           </div>
         </div>
 
         {/* Price and CTA */}
-        <div className="flex items-center justify-between mt-auto pt-4 border-t border-gray-200 dark:border-gray-700">
-          <div>
+        <div className="flex items-center justify-between mt-auto pt-3 sm:pt-4 border-t border-gray-200 dark:border-gray-700 gap-2">
+          <div className="min-w-0">
             <p className="text-xs text-gray-500 dark:text-gray-400">Total Value</p>
-            <p className="text-xl font-bold text-gray-900 dark:text-white">
+            <p className="text-base sm:text-xl font-bold text-gray-900 dark:text-white truncate">
               {formatPrice(property.price.total)}
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
             <button
               onClick={handleAddToCart}
-              className="px-3 py-2 bg-green-600 hover:bg-green-700 text-white font-medium rounded-lg transition-colors flex items-center gap-1"
+              className="px-2 sm:px-3 py-1.5 sm:py-2 bg-green-600 hover:bg-green-700 text-white text-xs sm:text-sm font-medium rounded-lg transition-colors flex items-center gap-1 flex-shrink-0"
               disabled={property.tokenInfo.available === 0}
+              title="Add to Cart"
             >
-              <ShoppingCart className="w-4 h-4" />
-              <Plus className="w-3 h-3" />
+              <ShoppingCart className="w-3 h-3 sm:w-4 sm:h-4" />
+              <Plus className="w-2 h-2 sm:w-3 sm:h-3" />
               <span className="hidden sm:inline">Add to Cart</span>
             </button>
-            <button className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors">
-              View Details
+            <button className="px-2 sm:px-4 py-1.5 sm:py-2 bg-blue-600 hover:bg-blue-700 text-white text-xs sm:text-sm font-medium rounded-lg transition-colors flex-shrink-0">
+              View
             </button>
           </div>
         </div>

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Moon, Sun } from 'lucide-react';
+
+export function ThemeSwitcher() {
+  const [isDark, setIsDark] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDarkMode = saved === 'dark' || (saved === null && prefersDark);
+
+    setIsDark(isDarkMode);
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newIsDark = !isDark;
+    setIsDark(newIsDark);
+
+    if (newIsDark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  };
+
+  if (!isMounted) {
+    return <div className="w-10 h-10" />;
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={toggleTheme}
+      className="gap-2"
+      data-testid="theme-switcher"
+    >
+      {isDark ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Fix four frontend bugs: dark mode state persistence, missing test ID for network switcher, duplicate Connect Wallet button, and mobile layout responsiveness at 375px.

## Changes

- **Issue #57**: Add ThemeSwitcher component with localStorage persistence for dark mode preference
- **Issue #55**: Add data-testid="network-switcher" attribute to NetworkSwitcher component
- **Issue #50**: Remove duplicate WalletConnector from homepage fallback UI  
- **Issue #59**: Improve PropertyCard responsive design for small viewports (375px)

## Testing

- [x] Components render without errors
- [x] Dark mode persists across page refreshes
- [x] Network switcher can be accessed via test ID
- [x] Only one Connect Wallet button visible at a time
- [x] Property cards display correctly at 375px width

## Checklist

- [x] Code follows project conventions
- [x] No unrelated changes included
- [x] Ready for review

Closes #57
Closes #55
Closes #50
Closes #59
