### PR TITLE
feat: add offline mode with service worker caching 

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PropChain — Offline</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f9fafb;
+        color: #111827;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #0b0f17;
+          color: #f3f4f6;
+        }
+      }
+      main {
+        max-width: 32rem;
+        padding: 2rem;
+        text-align: center;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        opacity: 0.8;
+        line-height: 1.5;
+      }
+      button {
+        margin-top: 1.5rem;
+        padding: 0.6rem 1.2rem;
+        border: none;
+        border-radius: 0.5rem;
+        background: #2563eb;
+        color: white;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #1d4ed8;
+      }
+      .badge {
+        display: inline-block;
+        margin-bottom: 1rem;
+        padding: 0.25rem 0.75rem;
+        border-radius: 999px;
+        background: rgba(37, 99, 235, 0.1);
+        color: #2563eb;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <span class="badge">Offline</span>
+      <h1>You are offline</h1>
+      <p>
+        We can't reach PropChain right now. Pages you've already visited remain
+        available, and any actions you take will be queued and retried once
+        you're back online.
+      </p>
+      <button type="button" onclick="window.location.reload()">
+        Try again
+      </button>
+    </main>
+  </body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,64 +1,303 @@
-const STATIC_CACHE = "propchain-static-v1";
-const RUNTIME_CACHE = "propchain-runtime-v1";
-const STATIC_ASSETS = ["/", "/favicon.ico"];
+/* PropChain service worker */
+/* eslint-disable no-restricted-globals */
+
+const SW_VERSION = "v2";
+const STATIC_CACHE = `propchain-static-${SW_VERSION}`;
+const RUNTIME_CACHE = `propchain-runtime-${SW_VERSION}`;
+const PROPERTIES_CACHE = `propchain-properties-${SW_VERSION}`;
+const IMAGE_CACHE = `propchain-images-${SW_VERSION}`;
+
+const KNOWN_CACHES = new Set([
+  STATIC_CACHE,
+  RUNTIME_CACHE,
+  PROPERTIES_CACHE,
+  IMAGE_CACHE,
+]);
+
+const STATIC_ASSETS = ["/", "/offline.html", "/favicon.ico"];
+
+// Cache invalidation strategy: each cache has a max age and a max entry count.
+// Entries older than maxAge are dropped on read; entries beyond maxEntries are
+// trimmed (oldest first) on write.
+const CACHE_LIMITS = {
+  [STATIC_CACHE]: { maxAge: 30 * 24 * 60 * 60 * 1000, maxEntries: 200 },
+  [RUNTIME_CACHE]: { maxAge: 7 * 24 * 60 * 60 * 1000, maxEntries: 100 },
+  [PROPERTIES_CACHE]: { maxAge: 24 * 60 * 60 * 1000, maxEntries: 150 },
+  [IMAGE_CACHE]: { maxAge: 30 * 24 * 60 * 60 * 1000, maxEntries: 250 },
+};
+
+const TRANSACTION_QUEUE_TAG = "propchain-transaction-queue";
+const TRANSACTION_QUEUE_DB = "propchain-offline-queue";
+const TRANSACTION_QUEUE_STORE = "transactions";
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(STATIC_CACHE).then((cache) => {
-      return cache.addAll(STATIC_ASSETS);
-    })
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .then(() => self.skipWaiting())
   );
-  self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys
-          .filter((key) => key !== STATIC_CACHE && key !== RUNTIME_CACHE)
-          .map((key) => caches.delete(key))
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => !KNOWN_CACHES.has(key))
+            .map((key) => caches.delete(key))
+        )
       )
-    )
+      .then(() => self.clients.claim())
   );
-  self.clients.claim();
 });
 
-self.addEventListener("fetch", (event) => {
-  if (event.request.method !== "GET") return;
+function isPropertyRequest(url) {
+  return (
+    url.pathname.startsWith("/properties") ||
+    url.pathname.startsWith("/mobile-properties") ||
+    url.pathname.startsWith("/api/properties")
+  );
+}
 
-  const url = new URL(event.request.url);
-  const isSameOrigin = url.origin === self.location.origin;
-  const isStatic =
+function isImageRequest(request, url) {
+  if (request.destination === "image") return true;
+  return /\.(?:png|jpg|jpeg|webp|avif|svg|gif|ico)$/i.test(url.pathname);
+}
+
+function isStaticAsset(url) {
+  return (
     url.pathname.startsWith("/_next/static") ||
-    /\.(?:png|jpg|jpeg|webp|avif|svg|ico|css|js)$/.test(url.pathname);
+    /\.(?:css|js|woff2?|ttf|otf|eot)$/i.test(url.pathname)
+  );
+}
 
-  if (isSameOrigin && isStatic) {
-    event.respondWith(
-      caches.match(event.request).then((cachedResponse) => {
-        if (cachedResponse) return cachedResponse;
-        return fetch(event.request).then((response) => {
-          const responseClone = response.clone();
-          caches.open(STATIC_CACHE).then((cache) => cache.put(event.request, responseClone));
-          return response;
-        });
-      })
-    );
+function withTimestamp(response) {
+  const headers = new Headers(response.headers);
+  headers.set("x-sw-cached-at", String(Date.now()));
+  return response
+    .blob()
+    .then((body) => new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }));
+}
+
+async function isExpired(response, maxAge) {
+  if (!response) return true;
+  const cachedAt = Number(response.headers.get("x-sw-cached-at") || 0);
+  if (!cachedAt) return false;
+  return Date.now() - cachedAt > maxAge;
+}
+
+async function trimCache(cacheName) {
+  const limit = CACHE_LIMITS[cacheName];
+  if (!limit) return;
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+  if (keys.length <= limit.maxEntries) return;
+  const excess = keys.length - limit.maxEntries;
+  await Promise.all(keys.slice(0, excess).map((key) => cache.delete(key)));
+}
+
+async function cachePut(cacheName, request, response) {
+  if (!response || !response.ok) return;
+  const cache = await caches.open(cacheName);
+  const stamped = await withTimestamp(response);
+  await cache.put(request, stamped);
+  trimCache(cacheName).catch(() => {});
+}
+
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const limit = CACHE_LIMITS[cacheName];
+  const expired = cached && limit ? await isExpired(cached, limit.maxAge) : false;
+
+  const networkPromise = fetch(request)
+    .then((response) => {
+      if (response && response.ok) {
+        const clone = response.clone();
+        cachePut(cacheName, request, clone).catch(() => {});
+      }
+      return response;
+    })
+    .catch(() => null);
+
+  if (cached && !expired) {
+    networkPromise.catch(() => {});
+    return cached;
+  }
+  const network = await networkPromise;
+  return network || cached || Response.error();
+}
+
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      const clone = response.clone();
+      cachePut(cacheName, request, clone).catch(() => {});
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    throw error;
+  }
+}
+
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const limit = CACHE_LIMITS[cacheName];
+  if (cached && (!limit || !(await isExpired(cached, limit.maxAge)))) {
+    return cached;
+  }
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      const clone = response.clone();
+      cachePut(cacheName, request, clone).catch(() => {});
+    }
+    return response;
+  } catch (error) {
+    if (cached) return cached;
+    throw error;
+  }
+}
+
+async function handleNavigation(request) {
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      cachePut(RUNTIME_CACHE, request, response.clone()).catch(() => {});
+    }
+    return response;
+  } catch (error) {
+    const cache = await caches.open(RUNTIME_CACHE);
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    const offline = await caches.match("/offline.html");
+    if (offline) return offline;
+    throw error;
+  }
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  const isSameOrigin = url.origin === self.location.origin;
+
+  if (request.mode === "navigate") {
+    event.respondWith(handleNavigation(request));
     return;
   }
 
-  if (isSameOrigin) {
-    event.respondWith(
-      caches.open(RUNTIME_CACHE).then(async (cache) => {
-        const cached = await cache.match(event.request);
-        const fetchPromise = fetch(event.request)
-          .then((response) => {
-            cache.put(event.request, response.clone());
-            return response;
-          })
-          .catch(() => cached);
-        return cached || fetchPromise;
-      })
+  if (!isSameOrigin) {
+    if (isImageRequest(request, url)) {
+      event.respondWith(cacheFirst(request, IMAGE_CACHE));
+    }
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
+
+  if (isImageRequest(request, url)) {
+    event.respondWith(cacheFirst(request, IMAGE_CACHE));
+    return;
+  }
+
+  if (isPropertyRequest(url)) {
+    event.respondWith(staleWhileRevalidate(request, PROPERTIES_CACHE));
+    return;
+  }
+
+  event.respondWith(networkFirst(request, RUNTIME_CACHE));
+});
+
+// --- Cache invalidation messages ---------------------------------------------
+self.addEventListener("message", (event) => {
+  const data = event.data || {};
+  if (data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+    return;
+  }
+  if (data.type === "CLEAR_CACHE") {
+    const target = data.cache;
+    event.waitUntil(
+      caches.keys().then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => (target ? key === target : KNOWN_CACHES.has(key)))
+            .map((key) => caches.delete(key))
+        )
+      )
     );
+    return;
+  }
+  if (data.type === "INVALIDATE_PROPERTIES") {
+    event.waitUntil(caches.delete(PROPERTIES_CACHE));
+    return;
+  }
+  if (data.type === "FLUSH_TRANSACTION_QUEUE") {
+    event.waitUntil(flushTransactionQueue());
   }
 });
+
+// --- Background sync for queued transactions --------------------------------
+self.addEventListener("sync", (event) => {
+  if (event.tag === TRANSACTION_QUEUE_TAG) {
+    event.waitUntil(flushTransactionQueue());
+  }
+});
+
+function openQueueDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(TRANSACTION_QUEUE_DB, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(TRANSACTION_QUEUE_STORE)) {
+        db.createObjectStore(TRANSACTION_QUEUE_STORE, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function readQueuedTransactions() {
+  const db = await openQueueDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(TRANSACTION_QUEUE_STORE, "readonly");
+    const store = tx.objectStore(TRANSACTION_QUEUE_STORE);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function notifyClients(message) {
+  const clients = await self.clients.matchAll({ includeUncontrolled: true });
+  clients.forEach((client) => client.postMessage(message));
+}
+
+async function flushTransactionQueue() {
+  let queued;
+  try {
+    queued = await readQueuedTransactions();
+  } catch {
+    return;
+  }
+  if (!queued.length) return;
+  await notifyClients({ type: "TRANSACTION_QUEUE_FLUSH_REQUEST" });
+}

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -5,6 +5,8 @@ import { config } from "@/config/wagmi";
 import { ChainAwareProvider } from "@/providers/ChainAwareProvider";
 import { QueryProvider } from "@/providers/QueryProvider";
 import { PerformanceMonitor } from "@/components/PerformanceMonitor";
+import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
+import { OfflineIndicator } from "@/components/OfflineIndicator";
 import "@/lib/i18n";
 import dynamic from "next/dynamic";
 
@@ -31,6 +33,8 @@ export function ClientProviders({ children }: ClientProvidersProps) {
       <QueryProvider>
         <ChainAwareProvider>
           <PerformanceMonitor />
+          <ServiceWorkerRegistration />
+          <OfflineIndicator />
           {children}
           <TransactionMonitor />
           <NotificationSystem />

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { WifiOff, RefreshCw } from "lucide-react";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+import {
+  getQueuedTransactions,
+  subscribeToQueue,
+  type QueuedTransaction,
+} from "@/lib/offlineTransactionQueue";
+
+const RECONNECTED_DURATION_MS = 4000;
+
+/**
+ * Persistent banner shown across the app.
+ *
+ *  - When offline: a red banner with the queued-transaction count.
+ *  - When the connection returns and there were queued transactions: a brief
+ *    success banner that auto-dismisses.
+ */
+export function OfflineIndicator(): React.ReactElement | null {
+  const isOnline = useOnlineStatus();
+  const [queueLength, setQueueLength] = useState(0);
+  const [showReconnected, setShowReconnected] = useState(false);
+  const [wasOffline, setWasOffline] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    getQueuedTransactions().then((items: QueuedTransaction[]) => {
+      if (mounted) setQueueLength(items.length);
+    });
+    const unsubscribe = subscribeToQueue((queue) => {
+      if (mounted) setQueueLength(queue.length);
+    });
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOnline) {
+      setWasOffline(true);
+      setShowReconnected(false);
+      return undefined;
+    }
+    if (wasOffline) {
+      setShowReconnected(true);
+      const timeout = window.setTimeout(
+        () => setShowReconnected(false),
+        RECONNECTED_DURATION_MS
+      );
+      return () => window.clearTimeout(timeout);
+    }
+    return undefined;
+  }, [isOnline, wasOffline]);
+
+  if (!isOnline) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="offline-banner"
+        className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-2 bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-md"
+      >
+        <WifiOff className="h-4 w-4" aria-hidden="true" />
+        <span>
+          You&apos;re offline — showing cached content.
+          {queueLength > 0 && (
+            <span className="ml-1 opacity-90">
+              {queueLength} pending transaction{queueLength === 1 ? "" : "s"}{" "}
+              will retry when you&apos;re back online.
+            </span>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  if (showReconnected) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="online-banner"
+        className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-2 bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-md"
+      >
+        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        <span>Back online — syncing pending updates.</span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/PerformanceMonitor.tsx
+++ b/src/components/PerformanceMonitor.tsx
@@ -34,12 +34,6 @@ export function PerformanceMonitor(): React.ReactElement | null {
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
 
-    if ("serviceWorker" in navigator) {
-      window.addEventListener("load", () => {
-        navigator.serviceWorker.register("/sw.js").catch(() => {});
-      });
-    }
-
     if ("PerformanceObserver" in window) {
       const longTaskObserver = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import { logger } from "@/utils/logger";
+import { startQueueAutoFlush } from "@/lib/offlineTransactionQueue";
+
+/**
+ * Registers the service worker, wires update notifications, and starts the
+ * offline transaction-queue auto-flush listener.
+ */
+export function ServiceWorkerRegistration(): null {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+    if (process.env.NODE_ENV === "test") return;
+
+    let cancelled = false;
+
+    const register = async () => {
+      try {
+        const registration = await navigator.serviceWorker.register("/sw.js");
+        if (cancelled) return;
+
+        registration.addEventListener("updatefound", () => {
+          const installing = registration.installing;
+          if (!installing) return;
+          installing.addEventListener("statechange", () => {
+            if (
+              installing.state === "installed" &&
+              navigator.serviceWorker.controller
+            ) {
+              installing.postMessage({ type: "SKIP_WAITING" });
+            }
+          });
+        });
+
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
+        });
+      } catch (error) {
+        logger.warn("Service worker registration failed", error);
+      }
+    };
+
+    if (document.readyState === "complete") {
+      register();
+    } else {
+      window.addEventListener("load", register, { once: true });
+    }
+
+    const stopAutoFlush = startQueueAutoFlush();
+
+    return () => {
+      cancelled = true;
+      stopAutoFlush();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/__tests__/OfflineIndicator.test.tsx
+++ b/src/components/__tests__/OfflineIndicator.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+jest.mock("@/lib/offlineTransactionQueue", () => ({
+  getQueuedTransactions: jest.fn().mockResolvedValue([]),
+  subscribeToQueue: jest.fn().mockReturnValue(() => {}),
+}));
+
+import { OfflineIndicator } from "@/components/OfflineIndicator";
+import {
+  getQueuedTransactions,
+  subscribeToQueue,
+} from "@/lib/offlineTransactionQueue";
+
+const setOnline = (value: boolean) => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+};
+
+describe("OfflineIndicator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setOnline(true);
+    (getQueuedTransactions as jest.Mock).mockResolvedValue([]);
+    (subscribeToQueue as jest.Mock).mockReturnValue(() => {});
+  });
+
+  it("renders nothing while online and no prior offline state", () => {
+    const { container } = render(<OfflineIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the offline banner when navigator goes offline", async () => {
+    render(<OfflineIndicator />);
+
+    await act(async () => {
+      setOnline(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(await screen.findByTestId("offline-banner")).toBeInTheDocument();
+    expect(screen.getByText(/offline/i)).toBeInTheDocument();
+  });
+
+  it("shows queued transaction count when present", async () => {
+    (getQueuedTransactions as jest.Mock).mockResolvedValueOnce([
+      { id: "1" },
+      { id: "2" },
+    ]);
+
+    render(<OfflineIndicator />);
+
+    await act(async () => {
+      setOnline(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("offline-banner")).toHaveTextContent(
+        /2 pending transactions/
+      )
+    );
+  });
+
+  it("shows reconnected banner after coming back online", async () => {
+    render(<OfflineIndicator />);
+
+    await act(async () => {
+      setOnline(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(screen.getByTestId("offline-banner")).toBeInTheDocument();
+
+    await act(async () => {
+      setOnline(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(await screen.findByTestId("online-banner")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks the browser's online/offline state. Returns `true` when online.
+ * On the server this hook returns `true` to avoid hydration mismatches; the
+ * real value is filled in on the client after mount.
+ */
+export const useOnlineStatus = (): boolean => {
+  const [isOnline, setIsOnline] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+
+    setIsOnline(navigator.onLine);
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+};

--- a/src/lib/__tests__/offlineTransactionQueue.test.ts
+++ b/src/lib/__tests__/offlineTransactionQueue.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockStore = new Map<string, unknown>();
+
+jest.mock("@/utils/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+type FakeRequest<T> = {
+  result: T;
+  onsuccess: (() => void) | null;
+  onerror: null;
+};
+
+const makeRequest = <T,>(result: T): FakeRequest<T> => {
+  const request: FakeRequest<T> = { result, onsuccess: null, onerror: null };
+  queueMicrotask(() => request.onsuccess?.());
+  return request;
+};
+
+const fakeStore = {
+  put: jest.fn((value: { id: string }) => {
+    mockStore.set(value.id, value);
+    return makeRequest(undefined);
+  }),
+  get: jest.fn((id: string) => makeRequest(mockStore.get(id))),
+  getAll: jest.fn(() => makeRequest(Array.from(mockStore.values()))),
+  delete: jest.fn((id: string) => {
+    mockStore.delete(id);
+    return makeRequest(undefined);
+  }),
+  clear: jest.fn(() => {
+    mockStore.clear();
+    return makeRequest(undefined);
+  }),
+};
+
+const fakeTransaction = () => {
+  const tx: {
+    objectStore: () => typeof fakeStore;
+    oncomplete: (() => void) | null;
+    onerror: null;
+    onabort: null;
+  } = {
+    objectStore: () => fakeStore,
+    oncomplete: null,
+    onerror: null,
+    onabort: null,
+  };
+  queueMicrotask(() => tx.oncomplete?.());
+  return tx;
+};
+
+const fakeDb = {
+  transaction: jest.fn(() => fakeTransaction()),
+  objectStoreNames: {
+    contains: () => true,
+  },
+};
+
+beforeEach(() => {
+  mockStore.clear();
+  jest.clearAllMocks();
+
+  (global as unknown as { indexedDB: unknown }).indexedDB = {
+    open: jest.fn(() => {
+      const request: {
+        result: typeof fakeDb;
+        onsuccess: (() => void) | null;
+        onerror: null;
+        onupgradeneeded: null;
+      } = {
+        result: fakeDb,
+        onsuccess: null,
+        onerror: null,
+        onupgradeneeded: null,
+      };
+      queueMicrotask(() => request.onsuccess?.());
+      return request;
+    }),
+  };
+});
+
+import {
+  enqueueTransaction,
+  getQueuedTransactions,
+  removeTransaction,
+  registerRetryHandler,
+  flushQueue,
+  clearQueue,
+} from "@/lib/offlineTransactionQueue";
+
+describe("offlineTransactionQueue", () => {
+  afterEach(async () => {
+    await clearQueue();
+  });
+
+  it("enqueues and reads back a transaction", async () => {
+    await enqueueTransaction({
+      type: "purchase",
+      payload: { propertyId: "abc" },
+    });
+
+    const queue = await getQueuedTransactions();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].type).toBe("purchase");
+    expect(queue[0].status).toBe("pending");
+  });
+
+  it("removes transactions on success when flushing", async () => {
+    const handler = jest.fn().mockResolvedValue(undefined);
+    registerRetryHandler("transfer", handler);
+
+    await enqueueTransaction({ type: "transfer", payload: { id: 1 } });
+    await flushQueue();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(await getQueuedTransactions()).toHaveLength(0);
+  });
+
+  it("keeps transactions and increments attempts on handler failure", async () => {
+    const handler = jest.fn().mockRejectedValue(new Error("nope"));
+    registerRetryHandler("management", handler);
+
+    await enqueueTransaction({
+      type: "management",
+      payload: {},
+      maxAttempts: 3,
+    });
+    await flushQueue();
+
+    const queue = await getQueuedTransactions();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].attempts).toBe(1);
+    expect(queue[0].status).toBe("pending");
+    expect(queue[0].error).toBe("nope");
+  });
+
+  it("marks as failed once max attempts reached", async () => {
+    const handler = jest.fn().mockRejectedValue(new Error("boom"));
+    registerRetryHandler("other", handler);
+
+    const tx = await enqueueTransaction({
+      type: "other",
+      payload: {},
+      maxAttempts: 1,
+    });
+    await flushQueue();
+
+    const [stored] = await getQueuedTransactions();
+    expect(stored.id).toBe(tx.id);
+    expect(stored.status).toBe("failed");
+  });
+
+  it("removeTransaction deletes the entry", async () => {
+    const tx = await enqueueTransaction({
+      type: "purchase",
+      payload: {},
+    });
+    await removeTransaction(tx.id);
+    expect(await getQueuedTransactions()).toHaveLength(0);
+  });
+});

--- a/src/lib/offlineTransactionQueue.ts
+++ b/src/lib/offlineTransactionQueue.ts
@@ -1,0 +1,268 @@
+/**
+ * Offline transaction queue
+ *
+ * Persists transactions that failed to send (or were initiated while offline)
+ * in IndexedDB and retries them when connectivity is restored. The same store
+ * is read by the service worker's background-sync handler so that retries can
+ * be triggered even when the page is closed.
+ */
+
+import { logger } from "@/utils/logger";
+
+export type QueuedTransactionStatus = "pending" | "retrying" | "failed";
+
+export interface QueuedTransaction {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  createdAt: number;
+  lastAttemptAt: number | null;
+  attempts: number;
+  maxAttempts: number;
+  status: QueuedTransactionStatus;
+  error?: string;
+  description?: string;
+}
+
+export type QueueChangeListener = (queue: QueuedTransaction[]) => void;
+
+const DB_NAME = "propchain-offline-queue";
+const DB_VERSION = 1;
+const STORE_NAME = "transactions";
+const SYNC_TAG = "propchain-transaction-queue";
+
+const listeners = new Set<QueueChangeListener>();
+
+const isBrowser = (): boolean =>
+  typeof window !== "undefined" && typeof indexedDB !== "undefined";
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => Promise<T>
+): Promise<T> {
+  const db = await openDb();
+  const tx = db.transaction(STORE_NAME, mode);
+  const store = tx.objectStore(STORE_NAME);
+  return operation(store);
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function notify(queue: QueuedTransaction[]) {
+  listeners.forEach((listener) => {
+    try {
+      listener(queue);
+    } catch (error) {
+      logger.warn("Offline queue listener threw", error);
+    }
+  });
+}
+
+export const subscribeToQueue = (listener: QueueChangeListener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const getQueuedTransactions = async (): Promise<QueuedTransaction[]> => {
+  if (!isBrowser()) return [];
+  try {
+    return await withStore("readonly", async (store) => {
+      const result = await requestToPromise(store.getAll());
+      return (result as QueuedTransaction[]) || [];
+    });
+  } catch (error) {
+    logger.warn("Failed to read offline transaction queue", error);
+    return [];
+  }
+};
+
+export const enqueueTransaction = async (
+  input: Omit<
+    QueuedTransaction,
+    "id" | "createdAt" | "lastAttemptAt" | "attempts" | "status" | "maxAttempts"
+  > & { id?: string; maxAttempts?: number }
+): Promise<QueuedTransaction> => {
+  const item: QueuedTransaction = {
+    id: input.id ?? `tx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type: input.type,
+    payload: input.payload,
+    description: input.description,
+    createdAt: Date.now(),
+    lastAttemptAt: null,
+    attempts: 0,
+    maxAttempts: input.maxAttempts ?? 5,
+    status: "pending",
+  };
+
+  if (!isBrowser()) return item;
+
+  await withStore("readwrite", async (store) => {
+    await requestToPromise(store.put(item));
+  });
+
+  await registerBackgroundSync();
+  const queue = await getQueuedTransactions();
+  notify(queue);
+  return item;
+};
+
+export const removeTransaction = async (id: string): Promise<void> => {
+  if (!isBrowser()) return;
+  await withStore("readwrite", async (store) => {
+    await requestToPromise(store.delete(id));
+  });
+  notify(await getQueuedTransactions());
+};
+
+export const updateTransaction = async (
+  id: string,
+  updates: Partial<QueuedTransaction>
+): Promise<QueuedTransaction | null> => {
+  if (!isBrowser()) return null;
+  const updated = await withStore<QueuedTransaction | null>(
+    "readwrite",
+    async (store) => {
+      const existing = (await requestToPromise(store.get(id))) as
+        | QueuedTransaction
+        | undefined;
+      if (!existing) return null;
+      const merged: QueuedTransaction = { ...existing, ...updates };
+      await requestToPromise(store.put(merged));
+      return merged;
+    }
+  );
+  notify(await getQueuedTransactions());
+  return updated;
+};
+
+export const clearQueue = async (): Promise<void> => {
+  if (!isBrowser()) return;
+  await withStore("readwrite", async (store) => {
+    await requestToPromise(store.clear());
+  });
+  notify([]);
+};
+
+export const registerBackgroundSync = async (): Promise<void> => {
+  if (!isBrowser()) return;
+  if (!("serviceWorker" in navigator)) return;
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const sync = (registration as ServiceWorkerRegistration & {
+      sync?: { register: (tag: string) => Promise<void> };
+    }).sync;
+    if (sync && typeof sync.register === "function") {
+      await sync.register(SYNC_TAG);
+    }
+  } catch (error) {
+    logger.debug("Background sync registration failed", error);
+  }
+};
+
+export type RetryHandler = (
+  transaction: QueuedTransaction
+) => Promise<unknown>;
+
+const handlers = new Map<string, RetryHandler>();
+
+export const registerRetryHandler = (
+  type: string,
+  handler: RetryHandler
+): (() => void) => {
+  handlers.set(type, handler);
+  return () => {
+    if (handlers.get(type) === handler) handlers.delete(type);
+  };
+};
+
+let flushInFlight: Promise<void> | null = null;
+
+export const flushQueue = async (): Promise<void> => {
+  if (!isBrowser()) return;
+  if (flushInFlight) return flushInFlight;
+
+  flushInFlight = (async () => {
+    const queue = await getQueuedTransactions();
+    for (const item of queue) {
+      const handler = handlers.get(item.type);
+      if (!handler) continue;
+      const next: QueuedTransaction = {
+        ...item,
+        status: "retrying",
+        attempts: item.attempts + 1,
+        lastAttemptAt: Date.now(),
+      };
+      await updateTransaction(item.id, next);
+      try {
+        await handler(next);
+        await removeTransaction(item.id);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Retry failed";
+        const exhausted = next.attempts >= next.maxAttempts;
+        await updateTransaction(item.id, {
+          status: exhausted ? "failed" : "pending",
+          error: message,
+        });
+      }
+    }
+  })().finally(() => {
+    flushInFlight = null;
+  });
+
+  return flushInFlight;
+};
+
+let connectivityListenerAttached = false;
+
+export const startQueueAutoFlush = (): (() => void) => {
+  if (!isBrowser()) return () => {};
+  if (connectivityListenerAttached) return () => {};
+  connectivityListenerAttached = true;
+
+  const onOnline = () => {
+    flushQueue().catch((error) =>
+      logger.warn("Failed to flush offline queue on reconnect", error)
+    );
+  };
+
+  window.addEventListener("online", onOnline);
+  if (navigator.onLine) {
+    flushQueue().catch(() => {});
+  }
+
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.addEventListener("message", (event) => {
+      const data = (event.data || {}) as { type?: string };
+      if (data.type === "TRANSACTION_QUEUE_FLUSH_REQUEST") {
+        onOnline();
+      }
+    });
+  }
+
+  return () => {
+    window.removeEventListener("online", onOnline);
+    connectivityListenerAttached = false;
+  };
+};


### PR DESCRIPTION
 ## Summary
  Closes #86. Adds full offline mode for PropChain.

  - New service worker with versioned caches (static / runtime / properties / images), TTL-based expiry, size-capped
  eviction, and an `/offline.html` fallback for navigations.
  - Caching strategies: network-first for navigations and runtime APIs, stale-while-revalidate for property listings
  (`/properties`, `/api/properties/*`), cache-first for `_next/static`, fonts, and images.
  - `ServiceWorkerRegistration` component handles install/update flow and reloads on `controllerchange`; old duplicate
  registration in `PerformanceMonitor` removed.
  - `OfflineIndicator` banner (driven by new `useOnlineStatus` hook) shows offline state, queued-transaction count, and a
  brief "back online" banner on reconnect.
  - IndexedDB-backed transaction retry queue (`offlineTransactionQueue`) with `registerRetryHandler`, attempt tracking,
  terminal `failed` state, and Background Sync support — auto-flushes on the `online` event.
  - Cache invalidation: per-entry timestamp + max-age, write-time entry-count trimming, `CLEAR_CACHE` /
  `INVALIDATE_PROPERTIES` / `FLUSH_TRANSACTION_QUEUE` page → SW messages, and `SW_VERSION` bump for full reset.

  ## Test plan
  - [ ] DevTools → Offline: cached pages load, banner appears, `/offline.html` served for new routes.
  - [ ] Queue a tx offline → toggle online → retry handler fires, banner flashes green.
  - [ ] Bump `SW_VERSION` and reload → old caches purged, app reloads cleanly.
  - [ ] `npx jest src/lib/__tests__/offlineTransactionQueue.test.ts src/components/__tests__/OfflineIndicator.test.tsx` → 9
  passing.