### PR TITLE
fix: add CSP headers and reporting endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ NODE_ENV=development
 # Enable build analysis (set to "true" for bundle analysis)
 ANALYZE=false
 
+# Enable CSP enforcement (set to "true" after report-only rollout)
+CSP_ENFORCE=false
+
 # -----------------------------------------------------------------------------
 # API Configurations
 # -----------------------------------------------------------------------------

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,27 @@
 import type { NextConfig } from "next";
 
 const isAnalyzeEnabled = process.env.ANALYZE === "true";
+const isDev = process.env.NODE_ENV === "development";
+
+const cspReportOnly = [
+  "default-src 'self'",
+  `script-src 'self'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https:",
+  isDev
+    ? "connect-src 'self' https: wss: ws: http:"
+    : "connect-src 'self' https: wss:",
+  "media-src 'self' data: blob: https:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  "report-uri /api/csp-report",
+  ...(isDev ? [] : ["upgrade-insecure-requests"]),
+].join("; ");
 
 const nextConfig: NextConfig = {
   experimental: {
@@ -70,6 +91,15 @@ const nextConfig: NextConfig = {
           {
             key: "Cache-Control",
             value: "no-cache, no-store, must-revalidate",
+          },
+        ],
+      },
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: cspReportOnly,
           },
         ],
       },

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,50 @@
+/**
+ * CSP Violation Reporting API Route
+ */
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { logger } from '@/utils/logger';
+import { withRateLimit } from '@/lib/rateLimit';
+
+async function handleCspReportPost(request: NextRequest) {
+  try {
+    const bodyText = await request.text();
+
+    if (!bodyText) {
+      return NextResponse.json(
+        { error: 'Empty report body' },
+        { status: 400 }
+      );
+    }
+
+    let report: unknown;
+
+    try {
+      report = JSON.parse(bodyText);
+    } catch {
+      report = { raw: bodyText };
+    }
+
+    logger.warn('CSP violation report received', {
+      report,
+      userAgent: request.headers.get('user-agent'),
+      referrer: request.headers.get('referer'),
+      url: request.nextUrl.toString(),
+    });
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    logger.error('Failed to process CSP report:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export const POST = withRateLimit(handleCspReportPost);
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/src/config/env/schema.ts
+++ b/src/config/env/schema.ts
@@ -15,6 +15,10 @@ const envSchema = z.object({
     .enum(["development", "staging", "production"])
     .default("development"),
   ANALYZE: z.string().optional().default("false"),
+  CSP_ENFORCE: z
+    .string()
+    .transform((val) => val === "true")
+    .default(false),
 
   // API Configurations
   NEXT_PUBLIC_PROPERTY_API_URL: z.string().url().optional(),
@@ -169,6 +173,7 @@ export const envVariableDescriptions: Record<keyof EnvConfig, string> = {
     "Base URL for the application (include protocol and trailing slash)",
   NODE_ENV: "Current deployment environment (development, staging, production)",
   ANALYZE: 'Enable build analysis (set to "true" for bundle analysis)',
+  CSP_ENFORCE: "Enable CSP enforcement (report-only when false)",
   NEXT_PUBLIC_PROPERTY_API_URL:
     "Property API endpoint for fetching property data",
   NEXT_PUBLIC_ANALYTICS_API_URL: "Analytics API endpoint",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,69 @@
 /**
- * Next.js Middleware for Redis Cache Initialization
- * Initializes Redis caching system for server-side requests
+ * Next.js Middleware for Redis Cache Initialization and CSP enforcement
+ * Initializes Redis caching system and applies nonce-based CSP when enabled
  */
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { initRedisCacheSystem } from '@/lib/initRedisCache';
 import { logger } from '@/utils/logger';
+
+const isDev = process.env.NODE_ENV === 'development';
+const isCspEnforced = process.env.CSP_ENFORCE === 'true';
+
+const createNonce = () => {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary);
+};
+
+const buildCspHeader = (nonce: string) => {
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'${isDev ? " 'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https:",
+    isDev
+      ? "connect-src 'self' https: wss: ws: http:"
+      : "connect-src 'self' https: wss:",
+    "media-src 'self' data: blob: https:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "report-uri /api/csp-report",
+  ];
+
+  if (!isDev) {
+    directives.push('upgrade-insecure-requests');
+  }
+
+  return directives.join('; ');
+};
+
+const shouldApplyCsp = (request: NextRequest) => {
+  const pathname = request.nextUrl.pathname;
+
+  if (pathname.startsWith('/api') || pathname === '/sw.js') {
+    return false;
+  }
+
+  const acceptHeader = request.headers.get('accept') || '';
+  return acceptHeader.includes('text/html');
+};
 
 // Flag to track if Redis has been initialized
 let redisInitialized = false;
@@ -26,8 +83,25 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Continue with the request
-  return NextResponse.next();
+  if (!isCspEnforced || !shouldApplyCsp(request)) {
+    return NextResponse.next();
+  }
+
+  const nonce = createNonce();
+  const cspHeader = buildCspHeader(nonce);
+  const requestHeaders = new Headers(request.headers);
+
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.set('Content-Security-Policy', cspHeader);
+
+  return response;
 }
 
 /**


### PR DESCRIPTION
## Closes #102

## Summary
Adds report-only CSP headers, a nonce-based enforcement path, and a CSP report endpoint.

## Root Cause
CSP headers and reporting were missing, leaving the app without XSS policy enforcement or violation telemetry.

## Changes
- Added report-only CSP configuration
- Added enforce-mode nonce CSP in middleware via `CSP_ENFORCE` flag
- Added `/api/csp-report` violation handler