### PR TITLE
fix: prevent wallet error logging when no extension present

### DIFF
--- a/src/utils/walletPersistence.ts
+++ b/src/utils/walletPersistence.ts
@@ -58,9 +58,16 @@ export const useWalletPersistence = () => {
           setDisconnected();
         }
       } catch (error) {
-        logger.error('Failed to check wallet connection:', error);
+        // Only log as error if we were previously connected, as this indicates
+        // a genuine connection issue. Otherwise, silence errors when no wallet
+        // extension is present (normal state).
         if (isConnected) {
+          logger.error('Failed to check wallet connection:', error);
           setDisconnected();
+        } else {
+          // Silently handle wallet connection errors when not connected
+          // This prevents console pollution when no wallet extension is present
+          logger.debug('Wallet provider unavailable:', error);
         }
       }
     };


### PR DESCRIPTION
 Fixes console pollution by preventing wallet connection errors from being logged when no wallet extension is present.

Problem: Browser console showed [ERROR] Failed to check wallet connection on every page load when no wallet extension was installed (normal state).

Solution: Modified error handling in walletPersistence.ts to only log errors when the wallet was previously connected. When not connected, errors are logged as DEBUG instead of ERROR.

Changes:

Updated catch block in checkWalletConnection() function
Added conditional logging based on isConnected state
Preserves error reporting for genuine connection issues
Testing: Verified both scenarios work correctly - no console pollution when no wallet, proper error logging when wallet has issues.

Closes #51 