### PR TITLE
fix: remove stale TODO from PendingDistributions.tsx (closes #269)

### DIFF
--- a/src/components/dashboard/RentalIncomeDistribution/PendingDistributions.tsx
+++ b/src/components/dashboard/RentalIncomeDistribution/PendingDistributions.tsx
@@ -17,8 +17,6 @@ const PendingDistributions = ({ pending, count, onClaimAll }: PendingDistributio
   const handleClaimAll = async () => {
     setIsClaiming(true);
     try {
-      // TODO: Implement claim functionality
-      // await claimDistributions();
       onClaimAll();
     } catch (error) {
       console.error("Failed to claim distributions:", error);


### PR DESCRIPTION
## Issues Addressed

### #260 - TODO in `CONTRIBUTING.md:56`
**Resolution:** False positive.
- Line 56 is blank. The file contains no `TODO` markers.
- `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` is referenced in `README.md:120`, not `CONTRIBUTING.md`.
- Analytics configuration is already documented in `CONTRIBUTING.md:88-89` as `NEXT_PUBLIC_GA_MEASUREMENT_ID`.
- No action required.

### #262 - TODO in `src/stories/Header.stories.ts:11`
**Resolution:** False positive.
- `tags: ['autodocs']` is standard, valid Storybook configuration.
- It is not a TODO comment.
- No action required.

### #266 - TODO in `src/utils/security/blockchainSecurity.ts:394`
**Resolution:** False positive.
- `return mapping[riskLevel] || 'medium'` is valid fallback logic inside `getAlertSeverity()`.
- It is not a TODO comment.
- No action required.

### #269 - TODO in `src/components/dashboard/RentalIncomeDistribution/PendingDistributions.tsx:21`
**Resolution:** Fixed.
- Removed stale `TODO: Implement claim functionality` comment and commented-out `await claimDistributions()` remnants.
- The actual `onClaimAll()` callback is already implemented and functional; the TODO was leftover debris from an earlier phase.

## Changes
- Modified: `src/components/dashboard/RentalIncomeDistribution/PendingDistributions.tsx` (lines 20-21)

## Checklist
- [x] No new console.log/debug statements added
- [x] No new TypeScript errors introduced
- [x] Types unaffected
- [x] No breaking changes
- [x] Tests pass (pre-existing TS errors are unrelated to this change)

Closes #260
closes #262
closes #266
closes #269