### PR TITLE
test: add MultiCurrencyBalance unit coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  watchman: false,
   moduleNameMapper: {
     // Handle module aliases (this will be automatically configured for you based on your tsconfig.json paths)
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/src/components/MultiCurrencyBalance.tsx
+++ b/src/components/MultiCurrencyBalance.tsx
@@ -25,14 +25,14 @@ export const MultiCurrencyBalance: React.FC = () => {
   useEffect(() => {
     if (!address || !balance) return;
 
-    // Fetch USD price for the native token
-    fetchUsdPrice();
-    
-    // Simulate fetching multiple token balances
-    fetchTokenBalances();
+    void (async () => {
+      const price = await fetchUsdPrice();
+      setUsdPrice(price);
+      await fetchTokenBalances(price);
+    })();
   }, [address, balance, chainId]);
 
-  const fetchUsdPrice = async () => {
+  const fetchUsdPrice = async (): Promise<number> => {
     try {
       // In production, use a real price API like CoinGecko
       const mockPrices: Record<number, number> = {
@@ -40,14 +40,14 @@ export const MultiCurrencyBalance: React.FC = () => {
         137: 0.85, // MATIC
         56: 600, // BNB
       };
-      const price = mockPrices[chainId] || 2000;
-      setUsdPrice(price);
+      return mockPrices[chainId] || 2000;
     } catch (error) {
       logger.error('Failed to fetch USD price:', error);
+      return 0;
     }
   };
 
-  const fetchTokenBalances = async () => {
+  const fetchTokenBalances = async (price: number) => {
     if (!address) return;
 
     // Mock token balances - in production, fetch from blockchain
@@ -56,8 +56,8 @@ export const MultiCurrencyBalance: React.FC = () => {
         symbol: chainConfig.symbol,
         name: chainConfig.name,
         balance: balance || '0',
-        usdValue: (parseFloat(balance || '0') * usdPrice).toFixed(2),
-        price: usdPrice,
+        usdValue: (parseFloat(balance || '0') * price).toFixed(2),
+        price,
       },
     ];
 

--- a/src/components/__tests__/MultiCurrencyBalance.test.tsx
+++ b/src/components/__tests__/MultiCurrencyBalance.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MultiCurrencyBalance } from '@/components/MultiCurrencyBalance';
+
+jest.mock('@/store/walletStore', () => ({
+  useWalletStore: jest.fn(),
+}));
+
+jest.mock('@/providers/ChainAwareProvider', () => ({
+  useChain: jest.fn(),
+}));
+
+const { useWalletStore } = jest.requireMock('@/store/walletStore') as {
+  useWalletStore: jest.Mock;
+};
+
+const { useChain } = jest.requireMock('@/providers/ChainAwareProvider') as {
+  useChain: jest.Mock;
+};
+
+describe('MultiCurrencyBalance', () => {
+  beforeEach(() => {
+    useChain.mockReset();
+    useWalletStore.mockReset();
+  });
+
+  it('renders nothing when wallet is not connected', () => {
+    useChain.mockReturnValue({
+      chainConfig: { symbol: 'ETH', name: 'Ethereum' },
+    });
+    useWalletStore.mockReturnValue({ balance: null, address: null, chainId: 1 });
+    const { container } = render(<MultiCurrencyBalance />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows native balance by default and can switch to USD display', async () => {
+    useChain.mockReturnValue({
+      chainConfig: { symbol: 'MATIC', name: 'Polygon' },
+    });
+    useWalletStore.mockReturnValue({
+      balance: '1.25',
+      address: '0xabc',
+      chainId: 137,
+    });
+
+    render(<MultiCurrencyBalance />);
+
+    // Opens dropdown
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText(/Wallet Balance/i)).toBeInTheDocument();
+
+    // Switch to USD mode
+    fireEvent.click(screen.getByRole('button', { name: 'USD' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('$1.06')[0]).toBeInTheDocument();
+    });
+  });
+
+  it('includes extra token balances on Ethereum mainnet', async () => {
+    useChain.mockReturnValue({
+      chainConfig: { symbol: 'ETH', name: 'Ethereum' },
+    });
+    useWalletStore.mockReturnValue({
+      balance: '2',
+      address: '0xabc',
+      chainId: 1,
+    });
+
+    render(<MultiCurrencyBalance />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText(/Token Balances/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('2 ETH').length).toBeGreaterThan(0);
+      expect(screen.getByText(/150\.00 USDT/)).toBeInTheDocument();
+      expect(screen.getByText(/250\.00 USDC/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows low balance indicator and warning when native balance is low', async () => {
+    useChain.mockReturnValue({
+      chainConfig: { symbol: 'ETH', name: 'Ethereum' },
+    });
+    useWalletStore.mockReturnValue({
+      balance: '0.009',
+      address: '0xabc',
+      chainId: 1,
+    });
+
+    render(<MultiCurrencyBalance />);
+
+    expect(await screen.findByText(/Low balance/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText(/Low Balance Warning/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused Jest tests for `MultiCurrencyBalance` (connected vs disconnected, USD toggle, mainnet extra tokens, low-balance warning).
- Fix USD value calculation to use the fetched price deterministically.
- Disable Watchman in Jest config to avoid local/CI permission crashes.

## Validation
- `npm test -- MultiCurrencyBalance.test.tsx`

Closes #288
Closes #289
Closes #290
Closes #291