### PR TITLE
fix: remove direct console logging in phishing reporting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  watchman: false,
   moduleNameMapper: {
     // Handle module aliases (this will be automatically configured for you based on your tsconfig.json paths)
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/src/utils/security/__tests__/reportSuspiciousDomain.test.ts
+++ b/src/utils/security/__tests__/reportSuspiciousDomain.test.ts
@@ -1,0 +1,34 @@
+import { PhishingProtection } from '../phishingProtection';
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('PhishingProtection.reportSuspiciousDomain', () => {
+  it('uses structured logger and does not call console directly', async () => {
+    const { logger } = jest.requireMock('@/utils/logger') as {
+      logger: { warn: jest.Mock; error: jest.Mock };
+    };
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = await PhishingProtection.reportSuspiciousDomain('evil.example', 'Unofficial domain');
+
+    expect(result).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith('[Security] Reporting suspicious domain', {
+      domain: 'evil.example',
+      reason: 'Unofficial domain',
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});
+

--- a/src/utils/security/phishingProtection.ts
+++ b/src/utils/security/phishingProtection.ts
@@ -1,4 +1,5 @@
 import { isAddress, isHex, recoverMessageAddress, type Hex } from 'viem';
+import { logger } from '@/utils/logger';
 
 export interface PhishingDetectionResult {
   isPhishing: boolean;
@@ -237,7 +238,7 @@ export class PhishingProtection {
   static async reportSuspiciousDomain(domain: string, reason: string): Promise<boolean> {
     try {
       // In a real implementation, this would send data to a security API
-      console.warn(`[Security] Reporting suspicious domain: ${domain}. Reason: ${reason}`);
+      logger.warn('[Security] Reporting suspicious domain', { domain, reason });
       
       // Placeholder for actual API call
       // await fetch('https://api.propchain.io/security/report', {
@@ -247,7 +248,7 @@ export class PhishingProtection {
       
       return true;
     } catch (error) {
-      console.error('Failed to report suspicious domain:', error);
+      logger.error('Failed to report suspicious domain', error);
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- Replace direct `console.warn/error` usage in phishing domain reporting with structured `logger` calls.
- Add a focused unit test ensuring `reportSuspiciousDomain` does not call `console` directly.
- Disable Watchman in Jest config to avoid local/CI permission crashes.

## Validation
- `npm test -- reportSuspiciousDomain.test.ts`

Closes #292
Closes #293
Closes #294
Closes #295