### PR TITLE
perf: optimize rendering in PageTransition component (#304)

### DIFF
--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React, { memo } from 'react';
+import { motion, AnimatePresence, type Variants, type Transition } from 'framer-motion';
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -9,7 +9,11 @@ interface PageTransitionProps {
   isDetail?: boolean;
 }
 
-const pageVariants = {
+// ============================================================================
+// Static animation variants (defined once outside components to avoid recreation)
+// ============================================================================
+
+const pageVariants: Variants = {
   initial: {
     opacity: 0,
     y: 20,
@@ -27,13 +31,13 @@ const pageVariants = {
   },
 };
 
-const pageTransition = {
-  type: 'tween' as const,
-  ease: 'anticipate' as const,
+const pageTransition: Transition = {
+  type: 'tween',
+  ease: 'anticipate',
   duration: 0.4,
 };
 
-const detailPageVariants = {
+const detailPageVariants: Variants = {
   initial: {
     opacity: 0,
     x: 100,
@@ -51,13 +55,13 @@ const detailPageVariants = {
   },
 };
 
-const detailPageTransition = {
-  type: 'spring' as const,
+const detailPageTransition: Transition = {
+  type: 'spring',
   stiffness: 300,
   damping: 30,
 };
 
-const modalVariants = {
+const modalVariants: Variants = {
   initial: {
     opacity: 0,
     scale: 0.8,
@@ -72,13 +76,68 @@ const modalVariants = {
   },
 };
 
-const modalTransition = {
-  type: 'spring' as const,
+const modalTransition: Transition = {
+  type: 'spring',
   stiffness: 400,
   damping: 25,
 };
 
-export const PageTransition: React.FC<PageTransitionProps> = ({ 
+const containerVariants: Variants = {
+  initial: { opacity: 0 },
+  in: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+      delayChildren: 0.2,
+    },
+  },
+  out: {
+    opacity: 0,
+    transition: {
+      staggerChildren: 0.05,
+      staggerDirection: -1,
+    },
+  },
+};
+
+const itemVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: 20,
+    scale: 0.8,
+  },
+  in: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+  },
+  out: {
+    opacity: 0,
+    y: -20,
+    scale: 0.8,
+  },
+};
+
+const itemTransition: Transition = {
+  type: 'spring',
+  stiffness: 300,
+  damping: 20,
+};
+
+const skeletonTransition: Transition = { duration: 0.2 };
+
+const contentEnterTransition: Transition = { 
+  type: 'spring',
+  stiffness: 400,
+  damping: 25,
+  duration: 0.3,
+};
+
+// ============================================================================
+// Page Transition
+// ============================================================================
+
+export const PageTransition = memo<PageTransitionProps>(({ 
   children, 
   className = '',
   isDetail = false 
@@ -98,9 +157,9 @@ export const PageTransition: React.FC<PageTransitionProps> = ({
       {children}
     </motion.div>
   );
-};
+});
 
-export const ModalTransition: React.FC<PageTransitionProps> = ({ children, className = '' }) => {
+export const ModalTransition = memo<PageTransitionProps>(({ children, className = '' }) => {
   return (
     <motion.div
       className={className}
@@ -113,28 +172,10 @@ export const ModalTransition: React.FC<PageTransitionProps> = ({ children, class
       {children}
     </motion.div>
   );
-};
+});
 
 // Stagger animation for property grids
-export const StaggerContainer: React.FC<PageTransitionProps> = ({ children, className = '' }) => {
-  const containerVariants = {
-    initial: { opacity: 0 },
-    in: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-        delayChildren: 0.2,
-      },
-    },
-    out: {
-      opacity: 0,
-      transition: {
-        staggerChildren: 0.05,
-        staggerDirection: -1,
-      },
-    },
-  };
-
+export const StaggerContainer = memo<PageTransitionProps>(({ children, className = '' }) => {
   return (
     <motion.div
       className={className}
@@ -146,48 +187,26 @@ export const StaggerContainer: React.FC<PageTransitionProps> = ({ children, clas
       {children}
     </motion.div>
   );
-};
+});
 
-export const StaggerItem: React.FC<PageTransitionProps> = ({ children, className = '' }) => {
-  const itemVariants = {
-    initial: {
-      opacity: 0,
-      y: 20,
-      scale: 0.8,
-    },
-    in: {
-      opacity: 1,
-      y: 0,
-      scale: 1,
-    },
-    out: {
-      opacity: 0,
-      y: -20,
-      scale: 0.8,
-    },
-  };
-
+export const StaggerItem = memo<PageTransitionProps>(({ children, className = '' }) => {
   return (
     <motion.div
       className={className}
       variants={itemVariants}
-      transition={{
-        type: 'spring',
-        stiffness: 300,
-        damping: 20,
-      }}
+      transition={itemTransition}
     >
       {children}
     </motion.div>
   );
-};
+});
 
 // Skeleton to content transition
-export const SkeletonToContent: React.FC<{
+export const SkeletonToContent = memo<{
   isLoading: boolean;
   children: React.ReactNode;
   className?: string;
-}> = ({ isLoading, children, className = '' }) => {
+}>(({ isLoading, children, className = '' }) => {
   return (
     <AnimatePresence mode="wait">
       {isLoading ? (
@@ -197,7 +216,7 @@ export const SkeletonToContent: React.FC<{
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
+          transition={skeletonTransition}
         >
           <div className="animate-pulse bg-gray-200 dark:bg-gray-700 rounded-lg h-48 w-full" />
         </motion.div>
@@ -208,16 +227,11 @@ export const SkeletonToContent: React.FC<{
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.95 }}
-          transition={{ 
-            type: 'spring',
-            stiffness: 400,
-            damping: 25,
-            duration: 0.3
-          }}
+          transition={contentEnterTransition}
         >
           {children}
         </motion.div>
       )}
     </AnimatePresence>
   );
-};
+});

--- a/src/components/__tests__/PageTransition.test.tsx
+++ b/src/components/__tests__/PageTransition.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { 
+  PageTransition, 
+  ModalTransition, 
+  StaggerContainer, 
+  StaggerItem, 
+  SkeletonToContent 
+} from '@/components/PageTransition';
+
+// Mock framer-motion
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
+      // Extract the key props for testing
+      const { initial, animate, exit, variants, transition, className, ...rest } = props;
+      return (
+        <div 
+          className={className as string}
+          data-testid={`motion-div`}
+          data-initial={typeof initial === 'string' ? initial : JSON.stringify(initial)}
+          data-animate={typeof animate === 'string' ? animate : JSON.stringify(animate)}
+          data-exit={typeof exit === 'string' ? exit : JSON.stringify(exit)}
+          {...rest}
+        >
+          {children}
+        </div>
+      );
+    },
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div data-testid="animate-presence">{children}</div>
+  ),
+}));
+
+describe('PageTransition', () => {
+  it('renders children with default page animation', () => {
+    render(
+      <PageTransition>
+        <p>Page content</p>
+      </PageTransition>
+    );
+
+    const motionDiv = screen.getByTestId('motion-div');
+    expect(motionDiv).toBeInTheDocument();
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+    expect(motionDiv).toHaveAttribute('data-initial', 'initial');
+    expect(motionDiv).toHaveAttribute('data-animate', 'in');
+    expect(motionDiv).toHaveAttribute('data-exit', 'out');
+  });
+
+  it('applies detail page variants when isDetail is true', () => {
+    render(
+      <PageTransition isDetail>
+        <p>Detail content</p>
+      </PageTransition>
+    );
+
+    expect(screen.getByText('Detail content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <PageTransition className="custom-class">
+        <p>Content</p>
+      </PageTransition>
+    );
+
+    const motionDiv = screen.getByTestId('motion-div');
+    expect(motionDiv.className).toContain('custom-class');
+  });
+
+  it('renders children without isDetail prop', () => {
+    render(
+      <PageTransition>
+        <p>Default page</p>
+      </PageTransition>
+    );
+
+    expect(screen.getByText('Default page')).toBeInTheDocument();
+  });
+});
+
+describe('ModalTransition', () => {
+  it('renders children with modal animation', () => {
+    render(
+      <ModalTransition>
+        <p>Modal content</p>
+      </ModalTransition>
+    );
+
+    const motionDiv = screen.getByTestId('motion-div');
+    expect(motionDiv).toBeInTheDocument();
+    expect(screen.getByText('Modal content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <ModalTransition className="modal-class">
+        <p>Content</p>
+      </ModalTransition>
+    );
+
+    const motionDiv = screen.getByTestId('motion-div');
+    expect(motionDiv.className).toContain('modal-class');
+  });
+});
+
+describe('StaggerContainer', () => {
+  it('renders children in a stagger container', () => {
+    render(
+      <StaggerContainer>
+        <p>Staggered content</p>
+      </StaggerContainer>
+    );
+
+    const motionDiv = screen.getByTestId('motion-div');
+    expect(motionDiv).toBeInTheDocument();
+    expect(screen.getByText('Staggered content')).toBeInTheDocument();
+  });
+});
+
+describe('StaggerItem', () => {
+  it('renders children as a stagger item', () => {
+    render(
+      <StaggerItem>
+        <p>Item content</p>
+      </StaggerItem>
+    );
+
+    expect(screen.getByText('Item content')).toBeInTheDocument();
+  });
+});
+
+describe('SkeletonToContent', () => {
+  it('renders skeleton when loading', () => {
+    const { container } = render(
+      <SkeletonToContent isLoading>
+        <p>Content</p>
+      </SkeletonToContent>
+    );
+
+    const pulseDiv = container.querySelector('.animate-pulse');
+    expect(pulseDiv).toBeInTheDocument();
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+  });
+
+  it('renders content when not loading', () => {
+    render(
+      <SkeletonToContent isLoading={false}>
+        <p>Loaded content</p>
+      </SkeletonToContent>
+    );
+
+    expect(screen.getByText('Loaded content')).toBeInTheDocument();
+  });
+
+  it('switches from skeleton to content when isLoading changes', () => {
+    const { rerender, container } = render(
+      <SkeletonToContent isLoading>
+        <p>Content</p>
+      </SkeletonToContent>
+    );
+
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+
+    rerender(
+      <SkeletonToContent isLoading={false}>
+        <p>Content</p>
+      </SkeletonToContent>
+    );
+
+    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary\nOptimize rendering performance of PageTransition component by applying React.memo and hoisting variant objects.\n\n## Changes\n- Applied `React.memo` to all 5 exported components (PageTransition, ModalTransition, StaggerContainer, StaggerItem, SkeletonToContent)\n- Moved variant/transition objects outside components to avoid recreation on each render\n- Imported `Variants` and `Transition` types from framer-motion for better type safety\n- Added 11 unit tests covering all components and edge cases\n\n
Closes #304