### PR TITLE
fix: improve i18n for ComparisonBar component (#307)

### DIFF
--- a/src/components/ComparisonBar.tsx
+++ b/src/components/ComparisonBar.tsx
@@ -3,11 +3,13 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Copy, ArrowRight, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { useCompareStore } from '@/store/compareStore';
 
 const MAX_COMPARE = 3;
 
 export const ComparisonBar = () => {
+  const { t } = useTranslation('common');
   const selectedIds = useCompareStore((state) => state.selectedIds);
   const removeProperty = useCompareStore((state) => state.removeProperty);
   const clearCompare = useCompareStore((state) => state.clearCompare);
@@ -41,7 +43,7 @@ export const ComparisonBar = () => {
       <div className="mx-auto max-w-6xl rounded-3xl border border-blue-200/70 bg-white/95 shadow-2xl shadow-blue-900/10 backdrop-blur-sm p-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between pointer-events-auto">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-6">
           <div className="rounded-2xl bg-blue-50 dark:bg-blue-900/10 px-4 py-3 text-sm text-blue-700 dark:text-blue-200 font-semibold">
-            Compare selected properties ({selectedIds.length}/{MAX_COMPARE})
+            {t('comparison.title', { count: selectedIds.length, max: MAX_COMPARE })}
           </div>
 
           <div className="flex flex-wrap gap-2">
@@ -51,6 +53,7 @@ export const ComparisonBar = () => {
                 type="button"
                 onClick={() => removeProperty(id)}
                 className="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-700 hover:border-red-300 hover:bg-red-50 transition-colors"
+                title={t('comparison.removeFromComparison')}
               >
                 <span>#{id}</span>
                 <Trash2 className="w-3.5 h-3.5" />
@@ -64,16 +67,17 @@ export const ComparisonBar = () => {
             type="button"
             onClick={handleCopy}
             className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
+            title={t('comparison.shareComparison')}
           >
             <Copy className="w-4 h-4" />
-            {copySuccess ? 'Link Copied' : 'Copy Comparison Link'}
+            {copySuccess ? t('comparison.linkCopied') : t('comparison.copyComparisonLink')}
           </button>
 
           <Link
             href={`/compare?ids=${selectedIds.join(',')}`}
             className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors"
           >
-            Compare Now
+            {t('comparison.compareNow')}
             <ArrowRight className="w-4 h-4" />
           </Link>
 
@@ -82,7 +86,7 @@ export const ComparisonBar = () => {
             onClick={clearCompare}
             className="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
           >
-            Clear
+            {t('comparison.clear')}
           </button>
         </div>
       </div>

--- a/src/components/__tests__/ComparisonBar.test.tsx
+++ b/src/components/__tests__/ComparisonBar.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComparisonBar } from '@/components/ComparisonBar';
+
+// Mock the compare store
+jest.mock('@/store/compareStore', () => ({
+  useCompareStore: jest.fn(),
+}));
+
+const mockUseCompareStore = jest.requireMock('@/store/compareStore').useCompareStore;
+
+// Mock react-i18next
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'comparison.title': `Compare selected properties (${String(params?.count ?? 0)}/${String(params?.max ?? 3)})`,
+        'comparison.copyComparisonLink': 'Copy Comparison Link',
+        'comparison.linkCopied': 'Link Copied',
+        'comparison.compareNow': 'Compare Now',
+        'comparison.clear': 'Clear',
+        'comparison.removeFromComparison': 'Remove from comparison',
+        'comparison.shareComparison': 'Share this comparison with others',
+      };
+      return translations[key] ?? key;
+    },
+    i18n: { language: 'en', changeLanguage: jest.fn() },
+  }),
+}));
+
+// Mock next/link
+jest.mock('next/link', () => {
+  // eslint-disable-next-line react/display-name
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+});
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+describe('ComparisonBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders nothing when no properties are selected', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: [], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    const { container } = render(<ComparisonBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders comparison bar with selected property IDs', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = {
+        selectedIds: ['prop1', 'prop2'],
+        removeProperty: jest.fn(),
+        clearCompare: jest.fn(),
+      };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    expect(screen.getByText(/Compare selected properties \(2\/3\)/)).toBeInTheDocument();
+    expect(screen.getByText('#prop1')).toBeInTheDocument();
+    expect(screen.getByText('#prop2')).toBeInTheDocument();
+    expect(screen.getByText('Copy Comparison Link')).toBeInTheDocument();
+    expect(screen.getByText('Compare Now')).toBeInTheDocument();
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('calls removeProperty when clicking a property chip', () => {
+    const removeProperty = jest.fn();
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1'], removeProperty, clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    const chipButton = screen.getByText('#prop1').closest('button');
+    expect(chipButton).not.toBeNull();
+    fireEvent.click(chipButton!);
+
+    expect(removeProperty).toHaveBeenCalledWith('prop1');
+  });
+
+  it('calls clearCompare when clicking clear button', () => {
+    const clearCompare = jest.fn();
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1', 'prop2'], removeProperty: jest.fn(), clearCompare };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    fireEvent.click(screen.getByText('Clear'));
+
+    expect(clearCompare).toHaveBeenCalled();
+  });
+
+  it('copies share URL when clicking copy button', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock },
+    });
+
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1', 'prop2'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    fireEvent.click(screen.getByText('Copy Comparison Link'));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalled();
+    });
+  });
+
+  it('shows copied feedback after copying link', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText: writeTextMock },
+    });
+
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    // Click copy button
+    fireEvent.click(screen.getByText('Copy Comparison Link'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Link Copied')).toBeInTheDocument();
+    });
+
+    // After timeout, should revert
+    jest.advanceTimersByTime(2000);
+
+    await waitFor(() => {
+      expect(screen.getByText('Copy Comparison Link')).toBeInTheDocument();
+    });
+  });
+
+  it('has correct link in Compare Now link', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1', 'prop2'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    const compareLink = screen.getByText('Compare Now').closest('a');
+    expect(compareLink).toHaveAttribute('href', '/compare?ids=prop1,prop2');
+  });
+
+  it('has correct shareUrl format', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1', 'prop2'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    const compareLink = screen.getByText('Compare Now').closest('a');
+    expect(compareLink).toHaveAttribute('href', expect.stringContaining('ids=prop1,prop2'));
+  });
+
+  it('shows correct count with single property', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    expect(screen.getByText(/Compare selected properties \(1\/3\)/)).toBeInTheDocument();
+  });
+
+  it('shows correct count with three properties', () => {
+    mockUseCompareStore.mockImplementation((selector: (state: Record<string, unknown>) => unknown) => {
+      const state = { selectedIds: ['prop1', 'prop2', 'prop3'], removeProperty: jest.fn(), clearCompare: jest.fn() };
+      return selector(state);
+    });
+
+    render(<ComparisonBar />);
+
+    expect(screen.getByText(/Compare selected properties \(3\/3\)/)).toBeInTheDocument();
+  });
+});

--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "يقيس مدى سهولة بيع أصولك بدون تأثير كبير على السعر.",
     "correlationDescription": "يوضح كيف تتحرك محفظتك مع اتجاهات السوق الأوسع."
   },
+  "comparison": {
+    "title": "مقارنة العقارات المحددة ({count}/{max})",
+    "copyComparisonLink": "نسخ رابط المقارنة",
+    "linkCopied": "تم نسخ الرابط",
+    "compareNow": "قارن الآن",
+    "clear": "مسح",
+    "removeFromComparison": "إزالة من المقارنة",
+    "comparisonLink": "رابط المقارنة",
+    "shareComparison": "شارك هذه المقارنة مع الآخرين"
+  },
   "geography": {
     "northAmerica": "أمريكا الشمالية",
     "europe": "أوروبا",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "Misst, wie einfach Sie Ihre Vermögenswerte ohne signifikanten Preisausfall verkaufen können.",
     "correlationDescription": "Zeigt, wie sich Ihr Portfolio mit breiteren Markttrends bewegt."
   },
+  "comparison": {
+    "title": "Ausgewählte Immobilien vergleichen ({count}/{max})",
+    "copyComparisonLink": "Vergleichslink kopieren",
+    "linkCopied": "Link kopiert",
+    "compareNow": "Jetzt vergleichen",
+    "clear": "Löschen",
+    "removeFromComparison": "Aus Vergleich entfernen",
+    "comparisonLink": "Vergleichslink",
+    "shareComparison": "Teilen Sie diesen Vergleich mit anderen"
+  },
   "geography": {
     "northAmerica": "Nordamerika",
     "europe": "Europa",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "Measures how easily you can sell your assets without significant price impact.",
     "correlationDescription": "Shows how your portfolio moves with broader market trends."
   },
+  "comparison": {
+    "title": "Compare selected properties ({count}/{max})",
+    "copyComparisonLink": "Copy Comparison Link",
+    "linkCopied": "Link Copied",
+    "compareNow": "Compare Now",
+    "clear": "Clear",
+    "removeFromComparison": "Remove from comparison",
+    "comparisonLink": "Comparison Link",
+    "shareComparison": "Share this comparison with others"
+  },
   "geography": {
     "northAmerica": "North America",
     "europe": "Europe",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "Mide qué tan fácilmente puedes vender tus activos sin impacto significativo en el precio.",
     "correlationDescription": "Muestra cómo se mueve tu portafolio con las tendencias del mercado más amplio."
   },
+  "comparison": {
+    "title": "Comparar propiedades seleccionadas ({count}/{max})",
+    "copyComparisonLink": "Copiar enlace de comparación",
+    "linkCopied": "Enlace copiado",
+    "compareNow": "Comparar ahora",
+    "clear": "Limpiar",
+    "removeFromComparison": "Eliminar de la comparación",
+    "comparisonLink": "Enlace de comparación",
+    "shareComparison": "Comparte esta comparación con otros"
+  },
   "geography": {
     "northAmerica": "América del Norte",
     "europe": "Europa",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "Mesure la facilité avec laquelle vous pouvez vendre vos actifs sans impact significatif sur le prix.",
     "correlationDescription": "Montre comment votre portefeuille évolue avec les tendances du marché plus large."
   },
+  "comparison": {
+    "title": "Comparer les propriétés sélectionnées ({count}/{max})",
+    "copyComparisonLink": "Copier le lien de comparaison",
+    "linkCopied": "Lien copié",
+    "compareNow": "Comparer maintenant",
+    "clear": "Effacer",
+    "removeFromComparison": "Retirer de la comparaison",
+    "comparisonLink": "Lien de comparaison",
+    "shareComparison": "Partagez cette comparaison avec d'autres"
+  },
   "geography": {
     "northAmerica": "Amérique du Nord",
     "europe": "Europe",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "מודד כמה קל למכור את הנכסים שלך ללא השפעה משמעותית על המחיר.",
     "correlationDescription": "מראה כיצד התיק שלך זז עם מגמות שוק רחבות יותר."
   },
+  "comparison": {
+    "title": "השוואת נכסים נבחרים ({count}/{max})",
+    "copyComparisonLink": "העתק קישור להשוואה",
+    "linkCopied": "הקישור הועתק",
+    "compareNow": "השווה עכשיו",
+    "clear": "ניקוי",
+    "removeFromComparison": "הסר מהשוואה",
+    "comparisonLink": "קישור להשוואה",
+    "shareComparison": "שתף השוואה זו עם אחרים"
+  },
   "geography": {
     "northAmerica": "צפון אמריקה",
     "europe": "אירופה",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -168,6 +168,16 @@
     "liquidityDescription": "衡量您在不产生重大价格影响的情况下出售资产的难易程度。",
     "correlationDescription": "显示您的投资组合如何与更广泛的市场趋势一起变动。"
   },
+  "comparison": {
+    "title": "比较选定的房产 ({count}/{max})",
+    "copyComparisonLink": "复制比较链接",
+    "linkCopied": "链接已复制",
+    "compareNow": "立即比较",
+    "clear": "清除",
+    "removeFromComparison": "从比较中移除",
+    "comparisonLink": "比较链接",
+    "shareComparison": "与他人分享此比较"
+  },
   "geography": {
     "northAmerica": "北美",
     "europe": "欧洲",


### PR DESCRIPTION
## Summary\nExtract hardcoded strings in ComparisonBar into i18n translation keys across all supported locales.\n\n## Changes\n- Added `useTranslation` hook to ComparisonBar component\n- Created `comparison` translation section in all 7 locale files (en, es, fr, de, zh, ar, he)\n- Keys include: title, copyComparisonLink, linkCopied, compareNow, clear, removeFromComparison, shareComparison\n- Added 10 unit tests covering all component states\n\n 
Closes #307