### PR TITLE
feat(MobilePropertyViewer): extract hardcoded strings into i18n translation keys

### DIFF
--- a/src/components/__tests__/MobilePropertyViewer.test.tsx
+++ b/src/components/__tests__/MobilePropertyViewer.test.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MobilePropertyViewer } from "../mobile/MobilePropertyViewer";
+import type { MobileProperty } from "@/types/mobileProperty";
+
+// Provide a minimal useTranslation implementation that returns keys with
+// interpolated values so tests can assert on the rendered output.
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (!options) return key;
+      // Replace {{placeholder}} with the corresponding option value
+      return key.replace(/\{\{(\w+)\}\}/g, (_: string, k: string) =>
+        String(options[k] ?? `{{${k}}}`),
+      );
+    },
+  }),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean; sizes?: string }) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  },
+}));
+
+const property: MobileProperty = {
+  id: "p1",
+  name: "Oceanview Residences",
+  location: "Miami, FL",
+  type: "Residential",
+  value: 750000,
+  tokens: 1500,
+  roi: 12.5,
+  monthlyIncome: 4000,
+  images: [
+    "https://example.com/img1.jpg",
+    "https://example.com/img2.jpg",
+    "https://example.com/img3.jpg",
+  ],
+  description: "Stunning oceanfront property with modern amenities.",
+  bedrooms: 3,
+  bathrooms: 2,
+  sqft: 2000,
+  amenities: ["Pool", "Gym", "Spa", "Concierge", "Valet"],
+};
+
+describe("MobilePropertyViewer", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <MobilePropertyViewer property={property} isOpen={false} onClose={jest.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the viewer when isOpen is true", () => {
+    render(
+      <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+    );
+    // Property images should be rendered
+    expect(screen.getAllByRole("img")).not.toHaveLength(0);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = jest.fn();
+    render(
+      <MobilePropertyViewer property={property} isOpen={true} onClose={onClose} />,
+    );
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe("image counter i18n", () => {
+    it("renders the image counter with translated interpolation", () => {
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+      // t("mobile.viewer.imageCounter", { current: 1, total: 3 }) should render "1 / 3"
+      // because the mock replaces {{current}} and {{total}}
+      expect(screen.getByText("1 / 3")).toBeInTheDocument();
+    });
+
+    it("advances the image counter when the next arrow is clicked", () => {
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+
+      // Find the chevron-right button (next image)
+      const nextBtn = screen.getAllByRole("button").find((btn) =>
+        btn.querySelector("svg"),
+      );
+      // Use the thumbnail strip instead — click the second thumbnail
+      const thumbnails = screen.getAllByRole("button").filter((btn) =>
+        btn.className.includes("rounded-lg"),
+      );
+      fireEvent.click(thumbnails[1]);
+
+      expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    });
+  });
+
+  describe("info panel i18n", () => {
+    beforeEach(() => {
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+      // Open the info panel by clicking the Info button (last header button)
+      const headerButtons = screen.getAllByRole("button").slice(0, 4);
+      fireEvent.click(headerButtons[headerButtons.length - 1]);
+    });
+
+    it("renders the translated value label", () => {
+      expect(screen.getByText("mobile.viewer.valueLabel")).toBeInTheDocument();
+    });
+
+    it("renders the translated ROI label", () => {
+      expect(screen.getByText("mobile.viewer.roiLabel")).toBeInTheDocument();
+    });
+
+    it("renders beds and baths with count interpolation", () => {
+      // t("mobile.viewer.bed", { count: 3 }) → "mobile.viewer.bed_other" with {{count}}=3
+      // Our mock returns the key with {{count}} replaced: "mobile.viewer.bed_other" → "3"
+      // Actually the mock returns: key.replace({{count}}, 3)
+      // The key will be "mobile.viewer.bed" with count=3 (i18next internally picks bed_other)
+      // Since our mock doesn't handle pluralisation we just verify the count value appears
+      expect(screen.getByText(/3/)).toBeInTheDocument();
+      expect(screen.getByText(/2/)).toBeInTheDocument();
+    });
+
+    it("renders the amenities overflow with translated key", () => {
+      // 5 amenities, 3 shown, 2 overflow → +{{count}} more → mock replaces {{count}} with 2
+      expect(screen.getByText(/\+.*2/)).toBeInTheDocument();
+    });
+  });
+
+  describe("action buttons i18n", () => {
+    it("renders the Contact button with translated label", () => {
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+      expect(
+        screen.getByText("mobile.viewer.contact"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the Schedule Tour button with translated label", () => {
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+      expect(
+        screen.getByText("mobile.viewer.scheduleTour"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("share i18n", () => {
+    it("calls navigator.share with the translated share text", async () => {
+      const shareMock = jest.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { share: shareMock });
+
+      render(
+        <MobilePropertyViewer property={property} isOpen={true} onClose={jest.fn()} />,
+      );
+
+      const shareBtn = screen.getAllByRole("button")[2]; // 3rd header button is Share
+      await fireEvent.click(shareBtn);
+
+      expect(shareMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: property.name,
+          text: expect.stringContaining(property.name),
+        }),
+      );
+    });
+  });
+});

--- a/src/components/mobile/MobilePropertyViewer.tsx
+++ b/src/components/mobile/MobilePropertyViewer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-
+import { useTranslation } from "react-i18next";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import type { PanInfo } from "framer-motion";
@@ -13,12 +13,10 @@ import {
   Phone,
   MapPin,
   Camera,
-  Play,
   ChevronLeft,
   ChevronRight,
   ZoomIn,
   ZoomOut,
-  Maximize2,
   Info,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,6 +34,8 @@ export const MobilePropertyViewer = ({
   isOpen,
   onClose,
 }: MobilePropertyViewerProps) => {
+  const { t } = useTranslation("common");
+
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [scale, setScale] = useState(1);
@@ -83,11 +83,16 @@ export const MobilePropertyViewer = ({
   };
 
   const handleShare = async () => {
+    const shareText = t("mobile.viewer.shareText", {
+      name: property.name,
+      location: property.location,
+    });
+
     if (navigator.share) {
       try {
         await navigator.share({
           title: property.name,
-          text: `Check out this property: ${property.name} in ${property.location}`,
+          text: shareText,
           url: window.location.href,
         });
       } catch (error) {
@@ -239,7 +244,10 @@ export const MobilePropertyViewer = ({
 
         {/* Image Counter */}
         <div className="absolute top-20 left-1/2 -translate-x-1/2 bg-black/50 text-white px-3 py-1 rounded-full text-sm">
-          {currentImageIndex + 1} / {property.images.length}
+          {t("mobile.viewer.imageCounter", {
+            current: currentImageIndex + 1,
+            total: property.images.length,
+          })}
         </div>
 
         {/* Thumbnail Strip */}
@@ -288,13 +296,17 @@ export const MobilePropertyViewer = ({
 
                 <div className="grid grid-cols-2 gap-4 mb-3">
                   <div>
-                    <p className="text-xs text-gray-300">Value</p>
+                    <p className="text-xs text-gray-300">
+                      {t("mobile.viewer.valueLabel")}
+                    </p>
                     <p className="font-semibold">
                       ${property.value.toLocaleString()}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-300">ROI</p>
+                    <p className="text-xs text-gray-300">
+                      {t("mobile.viewer.roiLabel")}
+                    </p>
                     <p
                       className={`font-semibold ${property.roi >= 0 ? "text-green-400" : "text-red-400"}`}
                     >
@@ -306,10 +318,19 @@ export const MobilePropertyViewer = ({
 
                 {property.bedrooms && property.bathrooms && (
                   <div className="flex gap-4 mb-3 text-sm">
-                    <span>{property.bedrooms} bed</span>
-                    <span>{property.bathrooms} bath</span>
+                    <span>
+                      {t("mobile.viewer.bed", { count: property.bedrooms })}
+                    </span>
+                    <span>
+                      {t("mobile.viewer.bath", { count: property.bathrooms })}
+                    </span>
                     {property.sqft && (
-                      <span>{property.sqft.toLocaleString()} sqft</span>
+                      <span>
+                        {t("mobile.viewer.sqft", {
+                          count: property.sqft,
+                          formattedCount: property.sqft.toLocaleString(),
+                        })}
+                      </span>
                     )}
                   </div>
                 )}
@@ -331,7 +352,9 @@ export const MobilePropertyViewer = ({
                     ))}
                     {property.amenities.length > 3 && (
                       <Badge variant="secondary" className="text-xs">
-                        +{property.amenities.length - 3} more
+                        {t("mobile.viewer.moreAmenities", {
+                          count: property.amenities.length - 3,
+                        })}
                       </Badge>
                     )}
                   </div>
@@ -347,14 +370,14 @@ export const MobilePropertyViewer = ({
               className="flex-1 bg-blue-600 hover:bg-blue-700"
             >
               <Phone className="w-4 h-4 mr-2" />
-              Contact
+              {t("mobile.viewer.contact")}
             </Button>
             <Button
               variant="outline"
               className="flex-1 border-white text-white hover:bg-white hover:text-black"
             >
               <Camera className="w-4 h-4 mr-2" />
-              Schedule Tour
+              {t("mobile.viewer.scheduleTour")}
             </Button>
           </div>
         </motion.div>

--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "معاينة عقار AR",
     "locationBasedDiscovery": "اكتشاف قائم على الموقع",
     "offlinePropertyCache": "ذاكرة تخزين مؤقت للعقارات بدون اتصال",
-    "mobilePropertyViewer": "عارض العقارات المحمول"
+    "mobilePropertyViewer": "عارض العقارات المحمول",
+    "viewer": {
+      "contact": "تواصل",
+      "scheduleTour": "جدولة جولة",
+      "valueLabel": "القيمة",
+      "roiLabel": "العائد على الاستثمار",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} المزيد",
+      "shareText": "اطلع على هذا العقار: {{name}} في {{location}}",
+      "bed_one": "{{count}} غرفة نوم",
+      "bed_other": "{{count}} غرف نوم",
+      "bath_one": "{{count}} حمام",
+      "bath_other": "{{count}} حمامات",
+      "sqft": "{{count}} قدم²"
+    }
   },
   "forms": {
     "selectYear": "اختر السنة",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "AR Immobilien-Vorschau",
     "locationBasedDiscovery": "Standortbasierte Entdeckung",
     "offlinePropertyCache": "Offline Immobilien-Cache",
-    "mobilePropertyViewer": "Mobiler Immobilien-Viewer"
+    "mobilePropertyViewer": "Mobiler Immobilien-Viewer",
+    "viewer": {
+      "contact": "Kontaktieren",
+      "scheduleTour": "Besichtigung planen",
+      "valueLabel": "Wert",
+      "roiLabel": "ROI",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} weitere",
+      "shareText": "Schauen Sie sich diese Immobilie an: {{name}} in {{location}}",
+      "bed_one": "{{count}} Schlafzimmer",
+      "bed_other": "{{count}} Schlafzimmer",
+      "bath_one": "{{count}} Bad",
+      "bath_other": "{{count}} Bäder",
+      "sqft": "{{count}} Fuß²"
+    }
   },
   "forms": {
     "selectYear": "Jahr auswählen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "AR Property Preview",
     "locationBasedDiscovery": "Location-Based Discovery",
     "offlinePropertyCache": "Offline Property Cache",
-    "mobilePropertyViewer": "Mobile Property Viewer"
+    "mobilePropertyViewer": "Mobile Property Viewer",
+    "viewer": {
+      "contact": "Contact",
+      "scheduleTour": "Schedule Tour",
+      "valueLabel": "Value",
+      "roiLabel": "ROI",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} more",
+      "shareText": "Check out this property: {{name}} in {{location}}",
+      "bed_one": "{{count}} bed",
+      "bed_other": "{{count}} beds",
+      "bath_one": "{{count}} bath",
+      "bath_other": "{{count}} baths",
+      "sqft": "{{count}} sqft"
+    }
   },
   "forms": {
     "selectYear": "Select year",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "Vista Previa de Propiedad AR",
     "locationBasedDiscovery": "Descubrimiento Basado en Ubicación",
     "offlinePropertyCache": "Caché de Propiedades Sin Conexión",
-    "mobilePropertyViewer": "Visor de Propiedades Móvil"
+    "mobilePropertyViewer": "Visor de Propiedades Móvil",
+    "viewer": {
+      "contact": "Contactar",
+      "scheduleTour": "Programar Visita",
+      "valueLabel": "Valor",
+      "roiLabel": "ROI",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} más",
+      "shareText": "Mira esta propiedad: {{name}} en {{location}}",
+      "bed_one": "{{count}} habitación",
+      "bed_other": "{{count}} habitaciones",
+      "bath_one": "{{count}} baño",
+      "bath_other": "{{count}} baños",
+      "sqft": "{{count}} pie²"
+    }
   },
   "forms": {
     "selectYear": "Seleccionar año",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "Aperçu de Propriété AR",
     "locationBasedDiscovery": "Découverte Basée sur la Localisation",
     "offlinePropertyCache": "Cache de Propriétés Hors Ligne",
-    "mobilePropertyViewer": "Visionneur de Propriétés Mobile"
+    "mobilePropertyViewer": "Visionneur de Propriétés Mobile",
+    "viewer": {
+      "contact": "Contacter",
+      "scheduleTour": "Planifier une Visite",
+      "valueLabel": "Valeur",
+      "roiLabel": "ROI",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} de plus",
+      "shareText": "Découvrez cette propriété : {{name}} à {{location}}",
+      "bed_one": "{{count}} chambre",
+      "bed_other": "{{count}} chambres",
+      "bath_one": "{{count}} salle de bain",
+      "bath_other": "{{count}} salles de bain",
+      "sqft": "{{count}} pi²"
+    }
   },
   "forms": {
     "selectYear": "Sélectionner l'année",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "תצוגה מקדימה של נכס AR",
     "locationBasedDiscovery": "גילוי מבוסס מיקום",
     "offlinePropertyCache": "מטמון נכסים לא מקוון",
-    "mobilePropertyViewer": "מציג נכסים נייד"
+    "mobilePropertyViewer": "מציג נכסים נייד",
+    "viewer": {
+      "contact": "יצירת קשר",
+      "scheduleTour": "תיאום סיור",
+      "valueLabel": "ערך",
+      "roiLabel": "תשואה",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} נוספות",
+      "shareText": "בדוק את הנכס הזה: {{name}} ב{{location}}",
+      "bed_one": "{{count}} חדר שינה",
+      "bed_other": "{{count}} חדרי שינה",
+      "bath_one": "{{count}} חדר אמבטיה",
+      "bath_other": "{{count}} חדרי אמבטיה",
+      "sqft": "{{count}} רגל²"
+    }
   },
   "forms": {
     "selectYear": "בחר שנה",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -131,7 +131,21 @@
     "arPropertyPreview": "AR房产预览",
     "locationBasedDiscovery": "基于位置的发现",
     "offlinePropertyCache": "离线房产缓存",
-    "mobilePropertyViewer": "移动房产查看器"
+    "mobilePropertyViewer": "移动房产查看器",
+    "viewer": {
+      "contact": "联系",
+      "scheduleTour": "预约参观",
+      "valueLabel": "价值",
+      "roiLabel": "投资回报率",
+      "imageCounter": "{{current}} / {{total}}",
+      "moreAmenities": "+{{count}} 更多",
+      "shareText": "查看这个房产：{{name}}，位于{{location}}",
+      "bed_one": "{{count}} 间卧室",
+      "bed_other": "{{count}} 间卧室",
+      "bath_one": "{{count}} 间浴室",
+      "bath_other": "{{count}} 间浴室",
+      "sqft": "{{count}} 平方英尺"
+    }
   },
   "forms": {
     "selectYear": "选择年份",


### PR DESCRIPTION
## Summary

Closes #327

Audits `MobilePropertyViewer.tsx` for hardcoded strings and extracts all of them into i18next translation keys backed by `useTranslation("common")`.

### Strings extracted

| Location | Old hardcoded text | New key |
|---|---|---|
| Contact button | `Contact` | `mobile.viewer.contact` |
| Schedule Tour button | `Schedule Tour` | `mobile.viewer.scheduleTour` |
| Info overlay | `Value` | `mobile.viewer.valueLabel` |
| Info overlay | `ROI` | `mobile.viewer.roiLabel` |
| Image counter | `{n} / {total}` | `mobile.viewer.imageCounter` (interpolated) |
| Amenities overflow | `+{n} more` | `mobile.viewer.moreAmenities` (interpolated) |
| Share payload | `Check out this property: ...` | `mobile.viewer.shareText` (interpolated) |
| Bedroom count | `{n} bed` | `mobile.viewer.bed` (plural keys: `_one` / `_other`) |
| Bathroom count | `{n} bath` | `mobile.viewer.bath` (plural keys: `_one` / `_other`) |
| Sqft | `{n} sqft` | `mobile.viewer.sqft` (interpolated) |

### Pluralization & RTL

Bedroom and bathroom counts use i18next `_one` / `_other` suffix keys. Arabic and Hebrew locales (RTL) already carry the new keys; extending to their full plural category sets (ar has 6 forms) can be done per-locale without touching the component. Layout direction is handled by the existing `dir` attribute on the HTML root.

### Locale coverage

All 7 locales updated: **en · es · fr · de · zh · ar · he**

## Test plan

- [ ] Component renders nothing when `isOpen={false}`
- [ ] Image counter shows `1 / {total}` on open, advances on thumbnail click
- [ ] Info panel shows translated `valueLabel` and `roiLabel`
- [ ] Amenity overflow badge interpolates count correctly
- [ ] Contact and Schedule Tour buttons render translated labels
- [ ] `navigator.share` is called with the translated share text
- [ ] Switch browser language to Spanish / French / Arabic and verify strings render in those languages
- [ ] `node_modules/.bin/tsc --noEmit --incremental false` passes with no new errors in modified files
