### PR TITLE
fix(referral): accessibility, web3 security, unit tests & visual snapshots (#328 #329 #330 #331)

### DIFF
--- a/src/components/__tests__/ReferralLeaderboard.test.tsx
+++ b/src/components/__tests__/ReferralLeaderboard.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ReferralLeaderboard from '@/components/referral/ReferralLeaderboard';
+import { ReferralTier } from '@/types/referral';
+
+// --- mocks ---
+
+jest.mock('wagmi', () => ({
+  useAccount: jest.fn(),
+}));
+
+jest.mock('@/store/referralStore', () => ({
+  useLeaderboardCache: jest.fn(() => null),
+  useReferralStore: jest.fn(() => ({
+    setLeaderboardLoading: jest.fn(),
+    setError: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/referralService', () => ({
+  referralService: {
+    getLeaderboard: jest.fn(),
+  },
+}));
+
+jest.mock('@/components/ui/LoadingSkeletons', () => ({
+  TableSkeleton: () => <div data-testid="table-skeleton" />,
+}));
+
+import { useAccount } from 'wagmi';
+import { useReferralStore } from '@/store/referralStore';
+import { referralService } from '@/lib/referralService';
+
+const mockUseAccount = useAccount as jest.Mock;
+const mockGetLeaderboard = referralService.getLeaderboard as jest.Mock;
+
+const sampleEntries = [
+  {
+    rank: 1,
+    referrerId: '0xAAAA000000000000000000000000000000000001',
+    displayName: 'Alice',
+    tier: ReferralTier.GOLD,
+    totalRewardsEarned: '1000000000000000000',
+    totalSignups: 80,
+    profileImage: null,
+  },
+  {
+    rank: 2,
+    referrerId: '0xBBBB000000000000000000000000000000000002',
+    displayName: 'Bob',
+    tier: ReferralTier.SILVER,
+    totalRewardsEarned: '500000000000000000',
+    totalSignups: 30,
+    profileImage: null,
+  },
+];
+
+const userEntry = {
+  rank: 5,
+  referrerId: '0xCCCC000000000000000000000000000000000003',
+  displayName: 'Me',
+  tier: ReferralTier.BRONZE,
+  totalRewardsEarned: '100000000000000000',
+  totalSignups: 5,
+  profileImage: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAccount.mockReturnValue({ address: '0xCCCC000000000000000000000000000000000003', chainId: 1 });
+  mockGetLeaderboard.mockResolvedValue({ entries: sampleEntries, userEntry });
+});
+
+describe('ReferralLeaderboard', () => {
+  it('shows connect-wallet prompt when no address', async () => {
+    mockUseAccount.mockReturnValue({ address: undefined, chainId: 1 });
+    render(<ReferralLeaderboard />);
+    expect(await screen.findByText(/connect wallet/i)).toBeInTheDocument();
+  });
+
+  it('shows loading skeleton while fetching', () => {
+    mockGetLeaderboard.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ReferralLeaderboard />);
+    expect(screen.getByTestId('table-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders leaderboard entries after successful fetch', async () => {
+    render(<ReferralLeaderboard />);
+    expect(await screen.findByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders user rank card when userEntry is returned', async () => {
+    render(<ReferralLeaderboard />);
+    expect(await screen.findByText('Your Position')).toBeInTheDocument();
+    expect(screen.getByText('#5')).toBeInTheDocument();
+  });
+
+  it('shows error message when fetch fails', async () => {
+    mockGetLeaderboard.mockRejectedValue(new Error('Network error'));
+    render(<ReferralLeaderboard />);
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+  });
+
+  it('shows empty state when entries array is empty', async () => {
+    mockGetLeaderboard.mockResolvedValue({ entries: [], userEntry: null });
+    render(<ReferralLeaderboard />);
+    await waitFor(() => expect(screen.queryByTestId('table-skeleton')).not.toBeInTheDocument());
+    expect(screen.getByText(/no leaderboard entries found/i)).toBeInTheDocument();
+  });
+
+  it('re-fetches when sort option changes', async () => {
+    render(<ReferralLeaderboard />);
+    await screen.findByText('Alice');
+
+    fireEvent.click(screen.getByRole('button', { name: /top signups/i }));
+
+    await waitFor(() => {
+      expect(mockGetLeaderboard).toHaveBeenCalledTimes(2);
+      expect(mockGetLeaderboard).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sortBy: 'totalSignups' }),
+      );
+    });
+  });
+
+  it('highlights the active sort button', async () => {
+    render(<ReferralLeaderboard />);
+    await screen.findByText('Alice');
+
+    const rewardsBtn = screen.getByRole('button', { name: /top rewards/i });
+    expect(rewardsBtn).toHaveClass('bg-blue-600');
+
+    fireEvent.click(screen.getByRole('button', { name: /most active/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /most active/i })).toHaveClass('bg-blue-600');
+      expect(rewardsBtn).not.toHaveClass('bg-blue-600');
+    });
+  });
+
+  it('does not render user position card when userEntry is null', async () => {
+    mockGetLeaderboard.mockResolvedValue({ entries: sampleEntries, userEntry: null });
+    render(<ReferralLeaderboard />);
+    await screen.findByText('Alice');
+    expect(screen.queryByText('Your Position')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/referral/ClaimRewardsModal.tsx
+++ b/src/components/referral/ClaimRewardsModal.tsx
@@ -1,15 +1,23 @@
 'use client';
 
-/**
- * ClaimRewardsModal - Modal for claiming on-chain rewards
- */
-
 import { useState } from 'react';
 import { useAccount } from 'wagmi';
 import { useReferralStore, useReferralStats } from '@/store/referralStore';
 import { referralService } from '@/lib/referralService';
 import { createWalletAddress } from '@/types/referral';
 import { formatUnits } from 'viem';
+
+const SUPPORTED_CHAIN_NAMES: Record<number, string> = {
+  1: 'Ethereum',
+  137: 'Polygon',
+  56: 'BSC',
+};
+
+function getChainName(chainId: number): string {
+  return SUPPORTED_CHAIN_NAMES[chainId] ?? `Chain ${chainId}`;
+}
+
+const MAX_REWARD_IDS = 50;
 
 export interface ClaimRewardsModalProps {
   rewardIds: string[];
@@ -38,6 +46,21 @@ export default function ClaimRewardsModal({
   const handleClaim = async () => {
     if (!address || !chainId) {
       setError('Wallet not connected');
+      return;
+    }
+
+    if (rewardIds.length === 0) {
+      setError('No rewards selected');
+      return;
+    }
+
+    if (rewardIds.length > MAX_REWARD_IDS) {
+      setError(`Cannot claim more than ${MAX_REWARD_IDS} rewards at once`);
+      return;
+    }
+
+    if (!SUPPORTED_CHAIN_NAMES[chainId]) {
+      setError(`Unsupported network (chain ID ${chainId}). Please switch to Ethereum, Polygon, or BSC.`);
       return;
     }
 
@@ -94,7 +117,7 @@ export default function ClaimRewardsModal({
               <div className="flex items-center justify-between text-sm text-slate-600">
                 <span>Network</span>
                 <span className="font-semibold capitalize">
-                  {chainId === 1 ? 'Ethereum' : chainId === 137 ? 'Polygon' : 'BSC'}
+                  {chainId ? getChainName(chainId) : 'Unknown'}
                 </span>
               </div>
             </div>

--- a/src/components/referral/ReferralTermsPage.tsx
+++ b/src/components/referral/ReferralTermsPage.tsx
@@ -1,10 +1,6 @@
 'use client';
 
-/**
- * Referral Terms and Conditions Page
- */
-
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { useAccount } from 'wagmi';
 import { useReferralStore } from '@/store/referralStore';
 import { referralService } from '@/lib/referralService';
@@ -17,6 +13,8 @@ export default function ReferralTermsPage() {
   const [accepted, setAccepted] = useState(false);
   const { termsAccepted, updateTermsAccepted, setNotification } =
     useReferralStore();
+  const checkboxId = useId();
+  const termsContentId = useId();
 
   useEffect(() => {
     setAccepted(termsAccepted);
@@ -56,11 +54,12 @@ export default function ReferralTermsPage() {
           <Link
             href="/referral"
             className="mb-4 inline-flex items-center text-blue-600 hover:text-blue-700"
+            aria-label="Back to referral dashboard"
           >
             ← Back to Dashboard
           </Link>
           <h1 className="text-4xl font-bold text-slate-900">
-            Referral Program Terms & Conditions
+            Referral Program Terms &amp; Conditions
           </h1>
           <p className="mt-2 text-slate-600">
             Last updated: {new Date().toLocaleDateString()}
@@ -68,7 +67,12 @@ export default function ReferralTermsPage() {
         </div>
 
         {/* Content */}
-        <div className="space-y-8 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+        <div
+          id={termsContentId}
+          role="document"
+          aria-label="Referral program terms and conditions"
+          className="space-y-8 rounded-lg border border-slate-200 bg-white p-8 shadow-sm"
+        >
           {/* 1. Eligibility */}
           <section>
             <h2 className="mb-4 text-2xl font-bold text-slate-900">
@@ -412,12 +416,14 @@ export default function ReferralTermsPage() {
                 <div className="flex items-start gap-4">
                   <input
                     type="checkbox"
-                    id="accept-terms"
+                    id={checkboxId}
                     checked={accepted}
                     onChange={(e) => setAccepted(e.target.checked)}
+                    aria-describedby={termsContentId}
+                    aria-checked={accepted}
                     className="mt-1 h-5 w-5 rounded border-slate-300"
                   />
-                  <label htmlFor="accept-terms" className="flex-1 text-slate-700">
+                  <label htmlFor={checkboxId} className="flex-1 text-slate-700">
                     I have read and agree to the PropChain Referral Program
                     Terms and Conditions. I understand that participation is
                     subject to these terms and that PropChain may enforce these
@@ -428,6 +434,12 @@ export default function ReferralTermsPage() {
                 <button
                   onClick={handleAccept}
                   disabled={!accepted || isAccepting || termsAccepted}
+                  aria-disabled={!accepted || isAccepting || termsAccepted}
+                  aria-label={
+                    termsAccepted
+                      ? 'Terms already accepted'
+                      : 'Accept the referral program terms and conditions'
+                  }
                   className="mt-6 w-full rounded-lg bg-green-600 px-4 py-3 font-semibold text-white transition-colors hover:bg-green-700 disabled:opacity-50"
                 >
                   {isAccepting
@@ -441,7 +453,10 @@ export default function ReferralTermsPage() {
           )}
 
           {!isConnected && (
-            <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-center text-yellow-800">
+            <div
+              role="alert"
+              className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-center text-yellow-800"
+            >
               Please connect your wallet to accept the terms and conditions
             </div>
           )}

--- a/src/stories/OfflinePropertyCache.stories.tsx
+++ b/src/stories/OfflinePropertyCache.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { OfflinePropertyCache } from '@/components/mobile/OfflinePropertyCache';
+import type { MobileProperty } from '@/types/mobileProperty';
+
+/**
+ * OfflinePropertyCache — Manages downloading, viewing, and removing cached
+ * property listings for offline access on mobile.
+ *
+ * ## Usage
+ * ```tsx
+ * import { OfflinePropertyCache } from '@/components/mobile/OfflinePropertyCache';
+ *
+ * <OfflinePropertyCache
+ *   properties={myProperties}
+ *   onPropertySelect={(p) => router.push(`/properties/${p.id}`)}
+ * />
+ * ```
+ *
+ * ## Props
+ * | Prop               | Type                               | Required | Description                               |
+ * |--------------------|------------------------------------|----------|-------------------------------------------|
+ * | `properties`       | `MobileProperty[]`                 | Yes      | Properties available for offline caching. |
+ * | `onPropertySelect` | `(property: MobileProperty) => void` | No     | Called when the user taps a cached item.  |
+ *
+ * ## Accessibility
+ * - Online/offline status is conveyed via labelled icons and text, not colour alone.
+ * - Buttons have visible labels or descriptive `aria-label` attributes.
+ * - Offline notice banner uses `role="alert"` (via framer-motion wrapper) to
+ *   announce its appearance to screen readers.
+ */
+const meta = {
+  title: 'Components/Mobile/OfflinePropertyCache',
+  component: OfflinePropertyCache,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Offline-first property cache manager. Allows users to download listings and browse them without an internet connection.',
+      },
+    },
+    chromatic: { viewports: [375, 768, 1280] },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof OfflinePropertyCache>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleProperties: MobileProperty[] = [
+  {
+    id: 'prop-1',
+    name: 'Oceanview Residences',
+    location: 'Miami, FL',
+    type: 'Residential',
+    value: 750000,
+    tokens: 1500,
+    roi: 12.5,
+    monthlyIncome: 4000,
+    images: [
+      'https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=800',
+      'https://images.unsplash.com/photo-1494526585095-c41746248156?w=800',
+    ],
+    description: 'Stunning oceanfront property.',
+    bedrooms: 3,
+    bathrooms: 2,
+    sqft: 2000,
+    amenities: ['Pool', 'Gym', 'Concierge'],
+  },
+  {
+    id: 'prop-2',
+    name: 'Downtown Loft',
+    location: 'Chicago, IL',
+    type: 'Commercial',
+    value: 450000,
+    tokens: 900,
+    roi: 9.2,
+    monthlyIncome: 2500,
+    images: [
+      'https://images.unsplash.com/photo-1502672260266-1c1ef2d93688?w=800',
+    ],
+    description: 'Modern loft in the heart of downtown.',
+    bedrooms: 1,
+    bathrooms: 1,
+    sqft: 900,
+    amenities: ['Doorman', 'Rooftop'],
+  },
+];
+
+/**
+ * Default — online state, two available properties, no cached entries yet.
+ */
+export const Default: Story = {
+  args: {
+    properties: sampleProperties,
+    onPropertySelect: undefined,
+  },
+};
+
+/**
+ * Empty — no properties available to download.
+ */
+export const Empty: Story = {
+  args: {
+    properties: [],
+  },
+};
+
+/**
+ * ManyProperties — stress test with a larger list to check layout at scale.
+ */
+export const ManyProperties: Story = {
+  args: {
+    properties: Array.from({ length: 12 }, (_, i) => ({
+      ...sampleProperties[0],
+      id: `prop-${i + 1}`,
+      name: `Property ${i + 1}`,
+      location: `City ${i + 1}, US`,
+    })),
+  },
+};


### PR DESCRIPTION
## Summary

This PR resolves four issues assigned to @NteinPrecious across accessibility, security, testing, and visual regression.

---

### #331 — Improve accessibility for `ReferralTermsPage.tsx`

WCAG 2.1 AA improvements:
- Replaced hard-coded `id="accept-terms"` with React `useId()` to guarantee unique IDs when the component is mounted multiple times in a page.
- `aria-describedby` on the checkbox now points to the terms content block, giving screen readers the full context before the user commits.
- `aria-checked` mirrors the controlled checkbox state for assistive technology.
- `aria-disabled` on the accept button reflects the disabled state semantically, not just visually.
- `aria-label` on the accept button provides a descriptive action string for screen readers.
- `role="document"` on the terms content wrapper signals to assistive technology that this is a long-form document region.
- `role="alert"` on the disconnected-wallet notice causes screen readers to announce it immediately when it appears.
- `aria-label` on the back link removes ambiguity (← icon alone is not descriptive).
- Replaced `&` with `&amp;` in the heading for valid HTML entities.

---

### #329 — Review security for web3 integrations in `ClaimRewardsModal.tsx`

Security concerns addressed:

| Issue | Before | After |
|---|---|---|
| Unknown chain IDs | Silently labelled as "BSC" | Rejected with an explicit error message |
| Empty `rewardIds` | Allowed through to the service | Caught early with a validation guard |
| Batch size | Unbounded | Capped at `MAX_REWARD_IDS = 50` |
| Chain name lookup | Fragile inline ternary | Typed `SUPPORTED_CHAIN_NAMES` record + `getChainName` helper |

---

### #330 — Add unit tests for `ReferralLeaderboard.tsx`

Added `src/components/__tests__/ReferralLeaderboard.test.tsx` with 8 test cases covering:
- No-wallet connect-prompt
- Loading skeleton display
- Successful data render (entries + user rank card)
- Network error message
- Empty state
- Sort button re-fetch (verifies `sortBy` param passed correctly)
- Active sort button highlight
- Null `userEntry` (no "Your Position" card)

All external dependencies mocked: `wagmi`, `referralStore`, `referralService`, `LoadingSkeletons`.

---

### #328 — Add visual regression test for `OfflinePropertyCache.tsx`

Added `src/stories/OfflinePropertyCache.stories.tsx` with:
- **Default** — online state, two properties, no cache yet.
- **Empty** — no properties available.
- **ManyProperties** — 12-property stress test for layout at scale.

Chromatic viewport set to `[375, 768, 1280]` to catch regressions across mobile, tablet, and desktop breakpoints. Full JSDoc with props table, usage example, and accessibility notes.

---

## Test plan

- [ ] Unit tests pass: `jest src/components/__tests__/ReferralLeaderboard.test.tsx`
- [ ] No TypeScript errors (`tsc --noEmit`)
- [ ] Storybook stories render without errors
- [ ] Screen reader announces wallet-disconnect notice immediately (role="alert")
- [ ] Claiming with an unsupported chain ID shows the error message
- [ ] Claiming with 0 selected rewards shows "No rewards selected"
