### PR TITLE
fix(referral): type safety, i18n extraction, visual snapshots & share security (#336 #337 #338 #339)

### DIFF
--- a/src/components/referral/QuickStats.tsx
+++ b/src/components/referral/QuickStats.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-/**
- * QuickStats - Quick statistics overview for referral dashboard
- */
-
 import { ReferralStats } from '@/types/referral';
 import { formatUnits } from 'viem';
 
@@ -11,12 +7,53 @@ export interface QuickStatsProps {
   stats: ReferralStats;
 }
 
+type StatColor = 'blue' | 'green' | 'purple' | 'yellow';
+
+interface StatCard {
+  label: string;
+  value: string;
+  icon: string;
+  color: StatColor;
+}
+
+interface ColorTokens {
+  bg: string;
+  border: string;
+  text: string;
+  accent: string;
+}
+
+const colorMap: Record<StatColor, ColorTokens> = {
+  blue: {
+    bg: 'bg-blue-50',
+    border: 'border-blue-200',
+    text: 'text-blue-900',
+    accent: 'text-blue-600',
+  },
+  green: {
+    bg: 'bg-green-50',
+    border: 'border-green-200',
+    text: 'text-green-900',
+    accent: 'text-green-600',
+  },
+  purple: {
+    bg: 'bg-purple-50',
+    border: 'border-purple-200',
+    text: 'text-purple-900',
+    accent: 'text-purple-600',
+  },
+  yellow: {
+    bg: 'bg-yellow-50',
+    border: 'border-yellow-200',
+    text: 'text-yellow-900',
+    accent: 'text-yellow-600',
+  },
+};
+
 export default function QuickStats({ stats }: QuickStatsProps) {
   const rewardAmount = formatUnits(BigInt(stats.totalRewardsEarned || 0), 18);
-  const claimedAmount = formatUnits(BigInt(stats.totalRewardsClaimed || 0), 18);
-  const pendingAmount = formatUnits(BigInt(stats.pendingRewards || 0), 18);
 
-  const statCards = [
+  const statCards: StatCard[] = [
     {
       label: 'Total Clicks',
       value: stats.totalClicks.toLocaleString(),
@@ -43,37 +80,10 @@ export default function QuickStats({ stats }: QuickStatsProps) {
     },
   ];
 
-  const colorMap = {
-    blue: {
-      bg: 'bg-blue-50',
-      border: 'border-blue-200',
-      text: 'text-blue-900',
-      accent: 'text-blue-600',
-    },
-    green: {
-      bg: 'bg-green-50',
-      border: 'border-green-200',
-      text: 'text-green-900',
-      accent: 'text-green-600',
-    },
-    purple: {
-      bg: 'bg-purple-50',
-      border: 'border-purple-200',
-      text: 'text-purple-900',
-      accent: 'text-purple-600',
-    },
-    yellow: {
-      bg: 'bg-yellow-50',
-      border: 'border-yellow-200',
-      text: 'text-yellow-900',
-      accent: 'text-yellow-600',
-    },
-  };
-
   return (
     <div className="grid gap-4 md:grid-cols-4">
       {statCards.map((card) => {
-        const colors = colorMap[card.color as keyof typeof colorMap];
+        const colors = colorMap[card.color];
         return (
           <div
             key={card.label}
@@ -88,7 +98,7 @@ export default function QuickStats({ stats }: QuickStatsProps) {
                   {card.value}
                 </p>
               </div>
-              <span className="text-2xl">{card.icon}</span>
+              <span className="text-2xl" aria-hidden="true">{card.icon}</span>
             </div>
           </div>
         );

--- a/src/components/referral/ReferralDashboard.tsx
+++ b/src/components/referral/ReferralDashboard.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-/**
- * ReferralDashboard - Main referral dashboard component
- * Displays user's referral stats, links, rewards, and leaderboard
- */
-
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAccount } from 'wagmi';
 import {
   useReferralStore,
@@ -31,6 +27,7 @@ export default function ReferralDashboard({
   showLeaderboard = true,
   compact = false,
 }: ReferralDashboardProps) {
+  const { t } = useTranslation('common');
   const { address, isConnected } = useAccount();
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -89,10 +86,10 @@ export default function ReferralDashboard({
     return (
       <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-6 text-center">
         <h3 className="mb-2 text-lg font-semibold text-yellow-900">
-          Connect Wallet
+          {t('referral.connectWallet')}
         </h3>
         <p className="text-yellow-800">
-          Please connect your wallet to access the referral program
+          {t('referral.connectWalletPrompt')}
         </p>
       </div>
     );
@@ -116,17 +113,17 @@ export default function ReferralDashboard({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-slate-900">
-            Referral Program
+            {t('referral.title')}
           </h1>
           <p className="mt-1 text-slate-600">
-            Earn rewards by inviting investors to PropChain
+            {t('referral.subtitle')}
           </p>
         </div>
         <Link
           href="/referral/terms"
           className="text-sm text-blue-600 underline hover:text-blue-700"
         >
-          View Terms
+          {t('referral.viewTerms')}
         </Link>
       </div>
 
@@ -149,17 +146,17 @@ export default function ReferralDashboard({
       {showLeaderboard && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 p-6">
           <h3 className="mb-2 flex items-center text-lg font-semibold text-blue-900">
-            <span className="mr-2">🏆</span>
-            Top Referrers
+            <span className="mr-2" aria-hidden="true">🏆</span>
+            {t('referral.topReferrers')}
           </h3>
           <p className="mb-4 text-blue-800">
-            Check how you rank among other referrers in the PropChain community.
+            {t('referral.leaderboardBlurb')}
           </p>
           <Link
             href="/referral/leaderboard"
             className="inline-block rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
           >
-            View Leaderboard →
+            {t('referral.viewLeaderboard')} →
           </Link>
         </div>
       )}

--- a/src/components/referral/ShareButton.tsx
+++ b/src/components/referral/ShareButton.tsx
@@ -1,23 +1,35 @@
 'use client';
 
-/**
- * ShareButton - Button for sharing referral links via social media or native share
- */
-
 import { useState } from 'react';
+import { logger } from '@/utils/logger';
 
 export interface ShareButtonProps {
   url: string;
   onShare?: () => void;
 }
 
+const SHARE_TEXT =
+  'Join PropChain - Invest in real estate through blockchain. Use my referral link and earn rewards!';
+
+function isSafeUrl(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 export default function ShareButton({ url, onShare }: ShareButtonProps) {
   const [showOptions, setShowOptions] = useState(false);
 
-  const shareVia = async (platform: string) => {
-    const text = encodeURIComponent(
-      'Join PropChain - Invest in real estate through blockchain. Use my referral link and earn rewards!'
-    );
+  const shareVia = (platform: string) => {
+    if (!isSafeUrl(url)) {
+      logger.error('ShareButton: refused to share unsafe URL', { url });
+      return;
+    }
+
+    const text = encodeURIComponent(SHARE_TEXT);
     const urlEncoded = encodeURIComponent(url);
     let shareUrl = '';
 
@@ -38,23 +50,29 @@ export default function ShareButton({ url, onShare }: ShareButtonProps) {
         return;
     }
 
-    window.open(shareUrl, 'share', 'width=600,height=400');
+    window.open(shareUrl, 'share', 'width=600,height=400,noopener,noreferrer');
     onShare?.();
     setShowOptions(false);
   };
 
   const handleNativeShare = async () => {
-    if (navigator.share) {
-      try {
-        await navigator.share({
-          title: 'PropChain Referral',
-          text: 'Join PropChain - Invest in real estate through blockchain!',
-          url: url,
-        });
-        onShare?.();
-        setShowOptions(false);
-      } catch (error) {
-        // User cancelled
+    if (!navigator.share) return;
+    if (!isSafeUrl(url)) {
+      logger.error('ShareButton: refused to share unsafe URL via native share', { url });
+      return;
+    }
+
+    try {
+      await navigator.share({
+        title: 'PropChain Referral',
+        text: 'Join PropChain - Invest in real estate through blockchain!',
+        url,
+      });
+      onShare?.();
+      setShowOptions(false);
+    } catch (error) {
+      if (error instanceof Error && error.name !== 'AbortError') {
+        logger.error('Native share failed:', error);
       }
     }
   };

--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -175,5 +175,15 @@
     "other": "أخرى",
     "byPropertyType": "حسب نوع العقار",
     "byGeography": "حسب الجغرافيا"
+  },
+  "referral": {
+    "connectWallet": "ربط المحفظة",
+    "connectWalletPrompt": "يرجى ربط محفظتك للوصول إلى برنامج الإحالة",
+    "title": "برنامج الإحالة",
+    "subtitle": "اكسب مكافآت بدعوة المستثمرين إلى PropChain",
+    "viewTerms": "عرض الشروط",
+    "topReferrers": "أفضل المحيلين",
+    "leaderboardBlurb": "تحقق من ترتيبك بين المحيلين في مجتمع PropChain.",
+    "viewLeaderboard": "عرض لوحة المتصدرين"
   }
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -175,5 +175,15 @@
     "other": "Andere",
     "byPropertyType": "Nach Immobilientyp",
     "byGeography": "Nach Geographie"
+  },
+  "referral": {
+    "connectWallet": "Wallet Verbinden",
+    "connectWalletPrompt": "Verbinde deine Wallet, um auf das Empfehlungsprogramm zuzugreifen",
+    "title": "Empfehlungsprogramm",
+    "subtitle": "Verdiene Belohnungen, indem du Investoren zu PropChain einlädst",
+    "viewTerms": "Bedingungen ansehen",
+    "topReferrers": "Top-Empfehlende",
+    "leaderboardBlurb": "Sieh, wie du im Ranking der PropChain-Community abschneidest.",
+    "viewLeaderboard": "Rangliste ansehen"
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -175,5 +175,15 @@
     "other": "Other",
     "byPropertyType": "By Property Type",
     "byGeography": "By Geography"
+  },
+  "referral": {
+    "connectWallet": "Connect Wallet",
+    "connectWalletPrompt": "Please connect your wallet to access the referral program",
+    "title": "Referral Program",
+    "subtitle": "Earn rewards by inviting investors to PropChain",
+    "viewTerms": "View Terms",
+    "topReferrers": "Top Referrers",
+    "leaderboardBlurb": "Check how you rank among other referrers in the PropChain community.",
+    "viewLeaderboard": "View Leaderboard"
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -175,5 +175,15 @@
     "other": "Otro",
     "byPropertyType": "Por Tipo de Propiedad",
     "byGeography": "Por Geografía"
+  },
+  "referral": {
+    "connectWallet": "Conectar Billetera",
+    "connectWalletPrompt": "Conecta tu billetera para acceder al programa de referidos",
+    "title": "Programa de Referidos",
+    "subtitle": "Gana recompensas invitando inversores a PropChain",
+    "viewTerms": "Ver Términos",
+    "topReferrers": "Mejores Referidores",
+    "leaderboardBlurb": "Consulta tu posición entre los referidores de la comunidad PropChain.",
+    "viewLeaderboard": "Ver Clasificación"
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -175,5 +175,15 @@
     "other": "Autre",
     "byPropertyType": "Par Type de Propriété",
     "byGeography": "Par Géographie"
+  },
+  "referral": {
+    "connectWallet": "Connecter le Portefeuille",
+    "connectWalletPrompt": "Connectez votre portefeuille pour accéder au programme de parrainage",
+    "title": "Programme de Parrainage",
+    "subtitle": "Gagnez des récompenses en invitant des investisseurs sur PropChain",
+    "viewTerms": "Voir les Conditions",
+    "topReferrers": "Meilleurs Parrains",
+    "leaderboardBlurb": "Découvrez votre classement parmi les parrains de la communauté PropChain.",
+    "viewLeaderboard": "Voir le Classement"
   }
 }

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -175,5 +175,15 @@
     "other": "אחר",
     "byPropertyType": "לפי סוג נכס",
     "byGeography": "לפי גאוגרפיה"
+  },
+  "referral": {
+    "connectWallet": "חבר ארנק",
+    "connectWalletPrompt": "חבר את הארנק שלך כדי לגשת לתוכנית ההפניות",
+    "title": "תוכנית הפניות",
+    "subtitle": "הרוויח תגמולים על ידי הזמנת משקיעים ל-PropChain",
+    "viewTerms": "הצג תנאים",
+    "topReferrers": "המפנים המובילים",
+    "leaderboardBlurb": "בדוק את דירוגך בין המפנים בקהילת PropChain.",
+    "viewLeaderboard": "הצג לוח מובילים"
   }
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -175,5 +175,15 @@
     "other": "其他",
     "byPropertyType": "按房产类型",
     "byGeography": "按地理位置"
+  },
+  "referral": {
+    "connectWallet": "连接钱包",
+    "connectWalletPrompt": "请连接您的钱包以访问推荐计划",
+    "title": "推荐计划",
+    "subtitle": "通过邀请投资者加入PropChain来赚取奖励",
+    "viewTerms": "查看条款",
+    "topReferrers": "顶级推荐人",
+    "leaderboardBlurb": "查看您在PropChain社区推荐者中的排名。",
+    "viewLeaderboard": "查看排行榜"
   }
 }

--- a/src/stories/ReferralLinksCard.stories.tsx
+++ b/src/stories/ReferralLinksCard.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ReferralLinksCard from '@/components/referral/ReferralLinksCard';
+import { useReferralStore } from '@/store/referralStore';
+
+/**
+ * ReferralLinksCard — Displays the authenticated user's referral links with
+ * copy and social-share actions. Also surfaces a button to create new links.
+ *
+ * ## Usage
+ * ```tsx
+ * import ReferralLinksCard from '@/components/referral/ReferralLinksCard';
+ *
+ * <ReferralLinksCard maxLinksToShow={3} />
+ * ```
+ *
+ * ## Props
+ * | Prop             | Type     | Default | Description                           |
+ * |------------------|----------|---------|---------------------------------------|
+ * | `maxLinksToShow` | `number` | `3`     | Max links rendered before the "View all" footer appears. |
+ *
+ * ## Accessibility
+ * - Copy and Share buttons each carry an `aria-label` describing their action.
+ * - "Create your first link" / "+ Create Link" button is keyboard reachable.
+ * - Link URLs are displayed as readable text (not hidden behind icons).
+ */
+const meta = {
+  title: 'Components/Referral/ReferralLinksCard',
+  component: ReferralLinksCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Card that lists a user\'s referral links with copy/share controls and a modal trigger to create new ones.',
+      },
+    },
+    chromatic: { viewports: [375, 768, 1280] },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ReferralLinksCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const seedLinks = (links: Parameters<typeof useReferralStore.getState>['0'] extends undefined ? never : ReturnType<typeof useReferralStore.getState>['referralLinks']) =>
+  (Story: React.ComponentType) => {
+    useReferralStore.setState({ referralLinks: links });
+    return <Story />;
+  };
+
+const sampleLinks = [
+  {
+    code: 'REF-ALPHA',
+    referrerId: '0xABCD000000000000000000000000000000000001' as `0x${string}`,
+    url: 'https://propchain.io/ref/REF-ALPHA',
+    shortUrl: 'https://pchn.io/r/ALPHA',
+    createdAt: Date.now() - 86400000 * 7,
+    isActive: true,
+    customName: 'Social Media Campaign',
+  },
+  {
+    code: 'REF-BETA',
+    referrerId: '0xABCD000000000000000000000000000000000001' as `0x${string}`,
+    url: 'https://propchain.io/ref/REF-BETA',
+    shortUrl: 'https://pchn.io/r/BETA',
+    createdAt: Date.now() - 86400000 * 2,
+    isActive: true,
+    customName: 'Discord Community',
+  },
+  {
+    code: 'REF-GAMMA',
+    referrerId: '0xABCD000000000000000000000000000000000001' as `0x${string}`,
+    url: 'https://propchain.io/ref/REF-GAMMA',
+    shortUrl: 'https://pchn.io/r/GAMMA',
+    createdAt: Date.now() - 3600000,
+    isActive: true,
+    customName: undefined,
+  },
+];
+
+/**
+ * Empty state — no links created yet.
+ */
+export const Empty: Story = {
+  decorators: [seedLinks([])],
+  args: {},
+};
+
+/**
+ * WithLinks — three active referral links.
+ */
+export const WithLinks: Story = {
+  decorators: [seedLinks(sampleLinks)],
+  args: {},
+};
+
+/**
+ * OverflowLinks — more links than `maxLinksToShow`, shows "View all N links" footer.
+ */
+export const OverflowLinks: Story = {
+  decorators: [
+    seedLinks([
+      ...sampleLinks,
+      {
+        code: 'REF-DELTA',
+        referrerId: '0xABCD000000000000000000000000000000000001' as `0x${string}`,
+        url: 'https://propchain.io/ref/REF-DELTA',
+        shortUrl: 'https://pchn.io/r/DELTA',
+        createdAt: Date.now(),
+        isActive: true,
+        customName: 'Email Newsletter',
+      },
+    ]),
+  ],
+  args: { maxLinksToShow: 3 },
+};


### PR DESCRIPTION
## Summary

This PR resolves four issues assigned to @JoeX17 covering TypeScript type safety, i18n, visual regression testing, and security.

---

### #336 — Add/tighten TypeScript types in `QuickStats.tsx`

**Before:** `statCards` was inferred as `{ color: string }[]`, requiring an unsafe `card.color as keyof typeof colorMap` cast at the call site.

**After:** Three new interfaces narrow the types precisely:

```ts
type StatColor = 'blue' | 'green' | 'purple' | 'yellow';
interface StatCard { label: string; value: string; icon: string; color: StatColor; }
interface ColorTokens { bg: string; border: string; text: string; accent: string; }
```

`colorMap` is typed `Record<StatColor, ColorTokens>` and moved to module scope (stable reference). The cast is gone — `colorMap[card.color]` is fully type-safe. Decorative emoji spans now carry `aria-hidden="true"`.

---

### #337 — Improve i18n for `ReferralDashboard.tsx`

**Before:** Eight hardcoded English strings directly in JSX:
- "Connect Wallet" / "Please connect your wallet..."
- "Referral Program" / "Earn rewards by inviting investors..."
- "View Terms"
- "Top Referrers" / "Check how you rank..."
- "View Leaderboard →"

**After:** All strings extracted to a `referral` namespace in all seven locale files:

| Locale | Status |
|--------|--------|
| `en` | Native |
| `es` | Translated |
| `fr` | Translated |
| `de` | Translated |
| `zh` | Translated |
| `ar` | Translated (RTL-ready) |
| `he` | Translated (RTL-ready) |

The component now uses `useTranslation('common')` and `t('referral.*')` calls. RTL languages (Arabic, Hebrew) work correctly because text is sourced from the locale file, not hardcoded.

---

### #338 — Add visual regression test for `ReferralLinksCard.tsx`

Added `src/stories/ReferralLinksCard.stories.tsx` with three stories:

| Story | State |
|---|---|
| **Empty** | No links created yet |
| **WithLinks** | Three named active links |
| **OverflowLinks** | Four links with `maxLinksToShow=3` — shows "View all" footer |

Chromatic viewport set to `[375, 768, 1280]`. Zustand store is seeded via a decorator before each story. Full JSDoc with props table, usage example, and accessibility notes.

---

### #339 — Review security for web3 integrations in `ShareButton.tsx`

Three security issues addressed:

| Issue | Before | After |
|---|---|---|
| Opener hijacking | `window.open(url, 'share', 'width=600,height=400')` | Added `noopener,noreferrer` to feature string |
| Arbitrary URL injection | Raw `url` prop encoded without validation | `isSafeUrl()` guard rejects non-http/s URLs before encoding |
| Silent native share errors | Empty `catch` block — failures invisible | Non-`AbortError` exceptions are now logged via `logger.error` |

closes #339 
closes #338
closes #337 
closes #336 

Also extracted the share text to a module-level `SHARE_TEXT` constant to keep it DRY and easier to update.

---

## Test plan

- [ ] `tsc --noEmit` passes with no new type errors
- [ ] Storybook builds: all three `ReferralLinksCard` stories render correctly
- [ ] Switching the app locale to Arabic/Hebrew shows translated referral dashboard strings
- [ ] Passing `url="javascript:alert(1)"` to `ShareButton` logs a security error and opens no popup
- [ ] Clicking a share platform button opens a popup with `noopener,noreferrer` in the feature string
