### PR TITLE
fix: resolve 3 assigned issues for jonathanayubausara-a11y (#459, #463, #464)

### DIFF
--- a/src/components/WalletModal.tsx
+++ b/src/components/WalletModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useWalletStore } from '@/store/walletStore';
 import { getWalletErrorMessage } from '@/utils/errorHandling';
 import { toChainId } from '@/config/chains';
@@ -173,8 +173,8 @@ export const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => 
     return null;
   };
 
-  // Detect installed wallets
-  const detectInstalledWallets = () => {
+  // Memoize wallet detection so it doesn't re-run on every render
+  const installedWallets = useMemo(() => {
     const installed = new Set<SupportedWalletId>();
     
     // Detect MetaMask
@@ -191,9 +191,7 @@ export const WalletModal: React.FC<WalletModalProps> = ({ isOpen, onClose }) => 
     // We'll consider it "available" but not "installed" in the traditional sense
     
     return installed;
-  };
-
-  const installedWallets = detectInstalledWallets();
+  }, []);
 
   const wallets: Array<{
     id: SupportedWalletId;

--- a/src/hooks/__tests__/useCurrencyConverter.test.ts
+++ b/src/hooks/__tests__/useCurrencyConverter.test.ts
@@ -1,0 +1,431 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCurrencyConverter } from '@/hooks/useCurrencyConverter';
+
+// Mock logger
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('useCurrencyConverter', () => {
+  const mockEthPrice = 3456.78;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockFetch.mockReset();
+  });
+
+  describe('Initial State', () => {
+    it('starts with loading true and null rate', () => {
+      // Don't resolve fetch so we can inspect initial state
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.ethToUsdRate).toBeNull();
+      expect(result.current.error).toBeNull();
+      expect(result.current.lastUpdated).toBeNull();
+    });
+  });
+
+  describe('Successful Rate Fetch', () => {
+    it('fetches and sets the ETH/USD rate', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: mockEthPrice } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBe(mockEthPrice);
+      expect(result.current.error).toBeNull();
+      expect(result.current.lastUpdated).toBeInstanceOf(Date);
+    });
+
+    it('saves rate to localStorage after successful fetch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: mockEthPrice } }),
+      });
+
+      renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(localStorage.getItem('ethToUsdRate')).toBe(mockEthPrice.toString());
+      });
+
+      expect(localStorage.getItem('ethToUsdLastUpdated')).toBeTruthy();
+    });
+  });
+
+  describe('HTTP Error Handling', () => {
+    it('handles non-ok HTTP responses', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: async () => ({}),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toContain('HTTP error');
+      expect(result.current.error).toContain('429');
+    });
+  });
+
+  describe('Network Error / Fetch Failure', () => {
+    it('handles network fetch failures gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('NetworkError'));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toBe('NetworkError');
+    });
+
+    it('falls back to cached rate on network error when localStorage has data', async () => {
+      // Pre-seed localStorage with cached data
+      localStorage.setItem('ethToUsdRate', mockEthPrice.toString());
+      localStorage.setItem('ethToUsdLastUpdated', new Date().toISOString());
+
+      mockFetch.mockRejectedValueOnce(new Error('NetworkError'));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should use cached rate on failure
+      expect(result.current.ethToUsdRate).toBe(mockEthPrice);
+      expect(result.current.lastUpdated).toBeInstanceOf(Date);
+    });
+
+    it('throws error with no cache on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('No internet connection'));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toBe('No internet connection');
+      expect(result.current.ethToUsdRate).toBeNull();
+    });
+  });
+
+  describe('Caching / Stale Data', () => {
+    it('uses cached rate when less than 60 seconds old', async () => {
+      // Pre-seed localStorage with recent cached data
+      localStorage.setItem('ethToUsdRate', mockEthPrice.toString());
+      const recentDate = new Date(Date.now() - 30 * 1000); // 30 seconds ago
+      localStorage.setItem('ethToUsdLastUpdated', recentDate.toISOString());
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      // Should immediately use cached data without fetching
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBe(mockEthPrice);
+      expect(result.current.lastUpdated).toEqual(recentDate);
+      // fetch should NOT have been called because cache is fresh
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches fresh data when cache is older than 60 seconds', async () => {
+      // Pre-seed localStorage with stale cached data
+      localStorage.setItem('ethToUsdRate', '3000');
+      const staleDate = new Date(Date.now() - 120 * 1000); // 120 seconds ago
+      localStorage.setItem('ethToUsdLastUpdated', staleDate.toISOString());
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: mockEthPrice } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should have fetched and updated to the new rate
+      expect(result.current.ethToUsdRate).toBe(mockEthPrice);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Storage Re-hydration', () => {
+    it('re-hydrates rate from localStorage on mount', async () => {
+      const cachedRate = 2500.50;
+      const cachedDate = new Date(Date.now() - 30 * 1000).toISOString();
+      localStorage.setItem('ethToUsdRate', cachedRate.toString());
+      localStorage.setItem('ethToUsdLastUpdated', cachedDate);
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBe(cachedRate);
+      expect(result.current.lastUpdated).toEqual(new Date(cachedDate));
+    });
+
+    it('handles missing cached date gracefully', async () => {
+      localStorage.setItem('ethToUsdRate', '2000');
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: mockEthPrice } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should fetch fresh data since no valid cache date
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Conversion Functions', () => {
+    it('convertEthToUsd converts ETH to USD correctly', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: 3000 } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.convertEthToUsd(2)).toBe(6000);
+      expect(result.current.convertEthToUsd(0.5)).toBe(1500);
+      expect(result.current.convertEthToUsd(0)).toBe(0);
+    });
+
+    it('convertEthToUsd returns null when rate is null', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      expect(result.current.convertEthToUsd(1)).toBeNull();
+    });
+
+    it('formatEthPrice formats ETH amount correctly', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      expect(result.current.formatEthPrice(1.5)).toBe('1.5000 ETH');
+      expect(result.current.formatEthPrice(2)).toBe('2.0000 ETH');
+    });
+
+    it('formatUsdPrice formats USD amount correctly', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: 3000 } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.formatUsdPrice(1)).toBe('$3,000.00');
+    });
+
+    it('formatUsdPrice returns null when rate is null', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      expect(result.current.formatUsdPrice(1)).toBeNull();
+    });
+  });
+
+  describe('Refetch Functionality', () => {
+    it('refetch triggers a new fetch and updates the rate', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ethereum: { usd: 3000 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ethereum: { usd: 3500 } }),
+        });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBe(3000);
+
+      // Manually refetch
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.ethToUsdRate).toBe(3500);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('refetch handles errors gracefully', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ethereum: { usd: 3000 } }),
+        })
+        .mockRejectedValueOnce(new Error('Refetch failed'));
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBe(3000);
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      // Should keep previous rate on refetch failure
+      expect(result.current.ethToUsdRate).toBe(3000);
+      expect(result.current.error).toBe('Refetch failed');
+    });
+  });
+
+  describe('Auto-refresh Interval', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ethereum: { usd: mockEthPrice } }),
+      });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('sets up an interval for auto-refresh', () => {
+      renderHook(() => useCurrencyConverter());
+
+      // Fast-forward 60 seconds
+      act(() => {
+        jest.advanceTimersByTime(60000);
+      });
+
+      // Should have triggered a second fetch
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears interval on unmount', () => {
+      const { unmount } = renderHook(() => useCurrencyConverter());
+      unmount();
+
+      act(() => {
+        jest.advanceTimersByTime(120000);
+      });
+
+      // Should only have the initial fetch call
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles response without ethereum.usd', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: {} }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBeNull();
+    });
+
+    it('handles response with null usd value', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: null } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBeNull();
+    });
+
+    it('handles response with undefined usd value', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ethereum: { usd: undefined } }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBeNull();
+    });
+
+    it('handles completely malformed response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ unexpected: 'data' }),
+      });
+
+      const { result } = renderHook(() => useCurrencyConverter());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.ethToUsdRate).toBeNull();
+    });
+  });
+});

--- a/src/utils/security/__tests__/qrCodeSecurity.test.ts
+++ b/src/utils/security/__tests__/qrCodeSecurity.test.ts
@@ -1,5 +1,36 @@
 import { validateQRCodeUrl, getDisplaySafeUrl, MAX_QR_CODE_URL_LENGTH } from '../qrCodeSecurity';
 
+// Mock PhishingProtection
+jest.mock('../phishingProtection', () => ({
+  PhishingProtection: {
+    detectPhishing: jest.fn((url: string) => {
+      // Simulate phishing detection for known patterns
+      if (url.includes('phishing') || url.includes('.fake') || url.includes('.scam')) {
+        return {
+          isPhishing: true,
+          riskScore: 90,
+          threats: ['Known phishing domain detected'],
+          warnings: [],
+        };
+      }
+      if (url.includes('suspicious')) {
+        return {
+          isPhishing: false,
+          riskScore: 50,
+          threats: [],
+          warnings: ['Suspicious domain pattern'],
+        };
+      }
+      return {
+        isPhishing: false,
+        riskScore: 0,
+        threats: [],
+        warnings: [],
+      };
+    }),
+  },
+}));
+
 describe('qrCodeSecurity', () => {
   describe('validateQRCodeUrl', () => {
     it('accepts valid HTTPS URLs', () => {
@@ -7,6 +38,20 @@ describe('qrCodeSecurity', () => {
 
       expect(result.isValid).toBe(true);
       expect(result.sanitizedUrl).toBe('https://propchain.io/properties/abc');
+    });
+
+    it('accepts valid HTTP URLs', () => {
+      const result = validateQRCodeUrl('http://example.com');
+
+      expect(result.isValid).toBe(true);
+      expect(result.sanitizedUrl).toBe('http://example.com/');
+    });
+
+    it('trims whitespace before validation', () => {
+      const result = validateQRCodeUrl('  https://propchain.io  ');
+
+      expect(result.isValid).toBe(true);
+      expect(result.sanitizedUrl).toBe('https://propchain.io/');
     });
 
     it('rejects empty URLs', () => {
@@ -20,6 +65,14 @@ describe('qrCodeSecurity', () => {
       expect(validateQRCodeUrl('javascript:alert(1)').error).toBe('unsafe_protocol');
       expect(validateQRCodeUrl('data:text/plain,hello').error).toBe('unsafe_protocol');
       expect(validateQRCodeUrl('blob:https://example.com/id').error).toBe('unsafe_protocol');
+    });
+
+    it('rejects vbscript protocol', () => {
+      const result = validateQRCodeUrl('vbscript:msgbox(1)');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('unsafe_protocol');
+      expect(result.warnings).toContain('Blocked unsafe URL protocol');
     });
 
     it('rejects malformed URLs', () => {
@@ -37,6 +90,16 @@ describe('qrCodeSecurity', () => {
       expect(result.error).toBe('url_too_long');
     });
 
+    it('accepts URLs at exactly max length', () => {
+      const baseUrl = 'https://propchain.io/';
+      const padding = 'a'.repeat(MAX_QR_CODE_URL_LENGTH - baseUrl.length);
+      const url = baseUrl + padding;
+
+      const result = validateQRCodeUrl(url);
+
+      expect(result.isValid).toBe(true);
+    });
+
     it('rejects known phishing domains', () => {
       const result = validateQRCodeUrl('https://metamask.io.fake/login');
 
@@ -50,11 +113,65 @@ describe('qrCodeSecurity', () => {
       expect(result.isValid).toBe(true);
       expect(result.warnings).toContain('URL host is not on the allowed list');
     });
+
+    it('accepts host that exactly matches allowed list', () => {
+      const result = validateQRCodeUrl('https://propchain.io/property/1', ['propchain.io']);
+
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).not.toContain('URL host is not on the allowed list');
+    });
+
+    it('accepts subdomain of an allowed host', () => {
+      const result = validateQRCodeUrl(
+        'https://app.propchain.io/property/1',
+        ['propchain.io']
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).not.toContain('URL host is not on the allowed list');
+    });
+
+    it('rejects unsupported protocols like deep-links', () => {
+      expect(validateQRCodeUrl('ethereum:0x1234').error).toBe('unsupported_protocol');
+      expect(validateQRCodeUrl('wc:1234@1?key=abc').error).toBe('unsupported_protocol');
+      expect(validateQRCodeUrl('ftp://files.example.com').error).toBe('unsupported_protocol');
+    });
+
+    it('rejects empty string after trimming', () => {
+      const result = validateQRCodeUrl('   ');
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe('empty_url');
+    });
+
+    it('includes warnings from non-phishing suspicious domains', () => {
+      const result = validateQRCodeUrl('https://suspicious.example.com');
+
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).toContain('Suspicious domain pattern');
+    });
+
+    it('handles URL with uppercase protocol', () => {
+      const result = validateQRCodeUrl('HTTPS://PROPCHAIN.IO');
+
+      expect(result.isValid).toBe(true);
+      expect(result.sanitizedUrl).toBe('https://propchain.io/');
+    });
   });
 
   describe('getDisplaySafeUrl', () => {
     it('returns empty string for invalid URLs', () => {
       expect(getDisplaySafeUrl('javascript:alert(1)')).toBe('');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(getDisplaySafeUrl('')).toBe('');
+    });
+
+    it('returns full URL when under max length', () => {
+      const result = getDisplaySafeUrl('https://propchain.io/short');
+
+      expect(result).toBe('https://propchain.io/short');
     });
 
     it('truncates long URLs for display', () => {
@@ -63,6 +180,14 @@ describe('qrCodeSecurity', () => {
 
       expect(display.endsWith('...')).toBe(true);
       expect(display.length).toBeLessThanOrEqual(50);
+    });
+
+    it('does not truncate URL at exact max length', () => {
+      const url = 'https://propchain.io/abc';
+      const result = getDisplaySafeUrl(url, url.length);
+
+      expect(result).toBe(url);
+      expect(result.endsWith('...')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses 3 issues assigned to @jonathanayubausara-a11y in the Stellar Wave program.

### Issue #459 (P3): WalletModal detection re-runs on every render
- **Problem**: `detectInstalledWallets` in `WalletModal` ran on every render even though `window.ethereum` cannot change between renders.
- **Fix**: Wrapped wallet detection in `useMemo` with an empty dependency array, so it runs only once on mount.
- **Files**: `src/components/WalletModal.tsx`

### Issue #463 (P2): Add unit tests for qrCodeSecurity
- **Problem**: `src/utils/security/qrCodeSecurity.ts` had insufficient test coverage.
- **Fix**: Added comprehensive test cases covering:
  - Phishing URL detection
  - Deep-link validation (ethereum:, wc:, ftp:)
  - Unsafe protocol blocking (vbscript:, javascript:, data:, blob:)
  - Whitespace trimming
  - Allowed host matching (exact and subdomain)
  - URL length boundary cases
  - Empty input after trimming
  - Uppercase protocol handling
  - Suspicious domain warnings
  - `getDisplaySafeUrl` edge cases (empty input, exact max length, truncation)
- Added jest mock for `PhishingProtection` to isolate tests
- **Files**: `src/utils/security/__tests__/qrCodeSecurity.test.ts`

### Issue #464 (P2): Add unit tests for useCurrencyConverter
- **Problem**: `src/hooks/useCurrencyConverter.ts` had no test file despite touching rate fetching, caching, and storage.
- **Fix**: Created comprehensive test suite with 24 tests covering:
  - Initial state (loading, null rate)
  - Successful ETH/USD rate fetch
  - HTTP error handling (429 status)
  - Network failures with localStorage cache fallback
  - Fresh cache reuse (<60 seconds)
  - Stale cache refresh (>60 seconds)
  - Storage re-hydration on mount
  - Conversion functions (convertEthToUsd, formatEthPrice, formatUsdPrice)
  - Refetch functionality with error handling
  - Auto-refresh interval setup and cleanup
  - Edge cases (missing/null/undefined/malformed responses)
  - Proper fake timer cleanup in beforeEach/afterEach
- **Files**: `src/hooks/__tests__/useCurrencyConverter.test.ts` (new)

## Verification
- [x] All 46 new/enhanced tests pass
- [x] useMemo properly prevents re-computation on re-renders
- [x] qrCodeSecurity tests cover phishing, deep-links, edge cases
- [x] useCurrencyConverter tests cover fetching, caching, conversion

closes #459
closes #463
closes #464