### PR TITLE
Fix viem unit helpers in Jest mock

### DIFF
--- a/__mocks__/viem.js
+++ b/__mocks__/viem.js
@@ -1,3 +1,69 @@
+const asBigInt = (value) =>
+  typeof value === 'bigint' ? value : BigInt(value);
+
+const formatUnitsValue = (value, decimals = 18) => {
+  const unitDecimals = Number(decimals);
+  const raw = asBigInt(value);
+  const sign = raw < 0n ? '-' : '';
+  const abs = raw < 0n ? -raw : raw;
+  const base = 10n ** BigInt(unitDecimals);
+  const whole = abs / base;
+  const fraction = abs % base;
+
+  if (unitDecimals === 0 || fraction === 0n) {
+    return `${sign}${whole}`;
+  }
+
+  const fractionText = fraction
+    .toString()
+    .padStart(unitDecimals, '0')
+    .replace(/0+$/, '');
+
+  return `${sign}${whole}.${fractionText}`;
+};
+
+const parseUnitsValue = (value, decimals = 18) => {
+  const unitDecimals = Number(decimals);
+  const text = String(value).trim();
+  const sign = text.startsWith('-') ? -1n : 1n;
+  const unsigned = text.replace(/^[+-]/, '');
+  const [whole = '0', fraction = ''] = unsigned.split('.');
+  const paddedFraction = fraction
+    .padEnd(unitDecimals, '0')
+    .slice(0, unitDecimals);
+  const normalized = `${whole || '0'}${paddedFraction || ''}`;
+  const parsed = BigInt(normalized || '0');
+
+  return sign * parsed;
+};
+
+const isAddressValue = (value) =>
+  typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value);
+
 module.exports = {
+  createPublicClient: jest.fn((config = {}) => ({
+    ...config,
+    getBalance: jest.fn(),
+    getBlockNumber: jest.fn(),
+    readContract: jest.fn(),
+    waitForTransactionReceipt: jest.fn(),
+  })),
+  fallback: jest.fn((transports) => ({ type: 'fallback', transports })),
+  formatEther: jest.fn((value) => formatUnitsValue(value, 18)),
+  formatUnits: jest.fn(formatUnitsValue),
+  getAddress: jest.fn((value) => {
+    if (!isAddressValue(value)) {
+      throw new Error('Invalid address');
+    }
+
+    return value;
+  }),
+  http: jest.fn((url) => ({ type: 'http', url })),
+  isAddress: jest.fn(isAddressValue),
+  isHex: jest.fn(
+    (value) => typeof value === 'string' && /^0x([a-fA-F0-9]{2})*$/.test(value),
+  ),
+  parseEther: jest.fn((value) => parseUnitsValue(value, 18)),
+  parseUnits: jest.fn(parseUnitsValue),
   recoverMessageAddress: jest.fn(() => Promise.resolve('0x123')),
 };

--- a/src/utils/__tests__/viemMock.test.ts
+++ b/src/utils/__tests__/viemMock.test.ts
@@ -1,0 +1,16 @@
+import { formatEther, formatUnits, parseEther, parseUnits } from 'viem';
+
+describe('viem Jest mock', () => {
+  it('formats integer token units like viem for component tests', () => {
+    expect(formatUnits(1000000000000000000n, 18)).toBe('1');
+    expect(formatUnits(1500000000000000000n, 18)).toBe('1.5');
+    expect(formatUnits(12345n, 3)).toBe('12.345');
+    expect(formatEther(2500000000000000000n)).toBe('2.5');
+  });
+
+  it('parses decimal token values into bigint stroops', () => {
+    expect(parseUnits('12.345', 3)).toBe(12345n);
+    expect(parseUnits('0.000000000000000001', 18)).toBe(1n);
+    expect(parseEther('2.5')).toBe(2500000000000000000n);
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic `formatUnits`, `formatEther`, `parseUnits`, and `parseEther` helpers to the Jest `viem` mock
- include small coverage for the mock's decimal formatting/parsing behavior
- keep production `viem` imports untouched

Fixes #616.

## Tests
- `npm test -- --runTestsByPath src/components/__tests__/ReferralLeaderboard.test.tsx src/utils/__tests__/viemMock.test.ts`

## Notes
- `npm run typecheck` is currently blocked by existing syntax/JSON errors outside this change, including `src/app/compare/page.tsx`, `src/lib/batchTransaction.ts`, locale JSON files, and `src/store/comparisonStore.ts`.
- `npm run lint` is currently blocked by existing parser/config issues outside this change, including missing ESLint rule definitions and the same pre-existing parse errors.