### PR TITLE
feat(ui): add UserProfileDropdown component

### DIFF
--- a/src/components/ui/UserProfileDropdown.tsx
+++ b/src/components/ui/UserProfileDropdown.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+export interface UserProfileDropdownProps {
+  user: {
+    name?: string;
+    email?: string;
+    avatar?: string;
+  };
+  onProfile?: () => void;
+  onSettings?: () => void;
+  onLogout?: () => void;
+  className?: string;
+}
+
+export function UserProfileDropdown({
+  user,
+  onProfile,
+  onSettings,
+  onLogout,
+  className,
+}: UserProfileDropdownProps) {
+  const initials = user.name
+    ?.split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2) || "??";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild className={cn("cursor-pointer", className)}>
+        <button className="flex items-center gap-2 rounded-full p-1 hover:bg-muted transition-colors">
+          <Avatar className="h-8 w-8">
+            <AvatarImage src={user.avatar} alt={user.name || "User"} />
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+          <span className="hidden sm:inline text-sm font-medium truncate max-w-[120px]">
+            {user.name || "User"}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium">{user.name || "User"}</p>
+            {user.email && (
+              <p className="text-xs text-muted-foreground truncate">
+                {user.email}
+              </p>
+            )}
+          </div>
+        </DropdownMenuLabel>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem onClick={onProfile} className="cursor-pointer">
+          <svg
+            className="mr-2 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+            />
+          </svg>
+          Profile
+        </DropdownMenuItem>
+
+        <DropdownMenuItem onClick={onSettings} className="cursor-pointer">
+          <svg
+            className="mr-2 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+          </svg>
+          Settings
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          onClick={onLogout}
+          className="cursor-pointer text-destructive focus:text-destructive"
+        >
+          <svg
+            className="mr-2 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+            />
+          </svg>
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

Implemented a user profile dropdown menu with avatar, profile, settings, and logout options.

### Changes

- Created UserProfileDropdown component
- User avatar with initials fallback
- Profile, Settings, and Logout menu items
- Responsive design with hidden name on mobile
- Keyboard accessible via Radix primitives
- Click outside to close

Closes #596