### PR TITLE
feat(ui): add PasswordInput with visibility toggle

### DIFF
--- a/src/components/ui/PasswordInput.tsx
+++ b/src/components/ui/PasswordInput.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+
+export interface PasswordInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  showToggle?: boolean;
+  toggleClassName?: string;
+}
+
+const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, showToggle = true, toggleClassName, ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false);
+
+    return (
+      <div className="relative">
+        <Input
+          ref={ref}
+          type={showPassword ? "text" : "password"}
+          className={cn("pr-10", className)}
+          {...props}
+        />
+        {showToggle && (
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            className={cn(
+              "absolute right-0 top-0 h-full px-3 flex items-center justify-center",
+              "text-muted-foreground hover:text-foreground transition-colors",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md",
+              toggleClassName
+            )}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                />
+              </svg>
+            )}
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };


### PR DESCRIPTION
## Summary

Implemented a password input component with toggle button to show/hide password.

### Changes

- Created PasswordInput component with visibility toggle
- Eye and eye-off icons for visibility state
- Accessible aria-labels for screen readers
- Keyboard accessible toggle button
- Matches existing Input component styling

Closes #598