### PR TITLE
feat(ui): add StickyTable components for sticky headers

### DIFF
--- a/src/components/ui/StickyTable.tsx
+++ b/src/components/ui/StickyTable.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface StickyTableProps extends React.HTMLAttributes<HTMLDivElement> {
+  maxHeight?: string;
+}
+
+function StickyTable({
+  children,
+  className,
+  maxHeight = "600px",
+  ...props
+}: StickyTableProps) {
+  return (
+    <div
+      className={cn("relative w-full overflow-auto", className)}
+      style={{ maxHeight }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface StickyTableHeaderProps extends React.HTMLAttributes<HTMLTableSectionElement> {
+  stickyClassName?: string;
+}
+
+function StickyTableHeader({
+  className,
+  stickyClassName,
+  ...props
+}: StickyTableHeaderProps) {
+  return (
+    <thead
+      data-slot="sticky-table-header"
+      className={cn(
+        "sticky top-0 z-10 bg-background",
+        stickyClassName,
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { StickyTable, StickyTableHeader };


### PR DESCRIPTION
## Summary

Implemented table wrapper and header components with sticky positioning for improved data table usability.

### Changes

- Created StickyTable component with configurable max height
- StickyTableHeader with sticky positioning
- Responsive layout with horizontal scrolling
- Compatible with existing Table components

Closes #600