### PR TITLE
fix(i18n): fix 7 broken locale JSON files

### DIFF
--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "تعذّر إنشاء رمز QR لهذا الرابط",
     "securityWarning": "شارك فقط روابط من نطاقات PropChain الموثوقة",
     "ariaLabel": "رمز QR لرابط العقار"
+  },
   "networkSwitcher": {
     "selectNetwork": "اختر الشبكة",
     "switchingNetwork": "جارٍ تبديل الشبكة..."
+  },
   "referral": {
     "connectWallet": "ربط المحفظة",
     "connectWalletPrompt": "يرجى ربط محفظتك للوصول إلى برنامج الإحالة",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "QR-Code für diese URL kann nicht generiert werden",
     "securityWarning": "Teilen Sie nur URLs von vertrauenswürdigen PropChain-Domains",
     "ariaLabel": "QR-Code für Immobilienlink"
+  },
   "networkSwitcher": {
     "selectNetwork": "Netzwerk auswählen",
     "switchingNetwork": "Netzwerk wird gewechselt..."
+  },
   "referral": {
     "connectWallet": "Wallet Verbinden",
     "connectWalletPrompt": "Verbinde deine Wallet, um auf das Empfehlungsprogramm zuzugreifen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -325,9 +325,11 @@
     "invalidUrl": "Unable to generate QR code for this URL",
     "securityWarning": "Only share URLs from trusted PropChain domains",
     "ariaLabel": "QR code for property link"
+  },
   "networkSwitcher": {
     "selectNetwork": "Select Network",
     "switchingNetwork": "Switching network..."
+  },
   "referral": {
     "connectWallet": "Connect Wallet",
     "connectWalletPrompt": "Please connect your wallet to access the referral program",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "No se puede generar un código QR para esta URL",
     "securityWarning": "Comparte solo URLs de dominios PropChain de confianza",
     "ariaLabel": "Código QR para enlace de propiedad"
+  },
   "networkSwitcher": {
     "selectNetwork": "Seleccionar red",
     "switchingNetwork": "Cambiando de red..."
+  },
   "referral": {
     "connectWallet": "Conectar Billetera",
     "connectWalletPrompt": "Conecta tu billetera para acceder al programa de referidos",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "Impossible de générer un code QR pour cette URL",
     "securityWarning": "Ne partagez que des URL de domaines PropChain de confiance",
     "ariaLabel": "Code QR pour le lien de la propriété"
+  },
   "networkSwitcher": {
     "selectNetwork": "Sélectionner le réseau",
     "switchingNetwork": "Changement de réseau..."
+  },
   "referral": {
     "connectWallet": "Connecter le Portefeuille",
     "connectWalletPrompt": "Connectez votre portefeuille pour accéder au programme de parrainage",

--- a/src/locales/he/common.json
+++ b/src/locales/he/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "לא ניתן ליצור QR Code עבור כתובת URL זו",
     "securityWarning": "שתף רק כתובות URL מדומיינים מהימנים של PropChain",
     "ariaLabel": "QR Code לקישור נכס"
+  },
   "networkSwitcher": {
     "selectNetwork": "בחר רשת",
     "switchingNetwork": "מחליף רשת..."
+  },
   "referral": {
     "connectWallet": "חבר ארנק",
     "connectWalletPrompt": "חבר את הארנק שלך כדי לגשת לתוכנית ההפניות",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -292,9 +292,11 @@
     "invalidUrl": "无法为此 URL 生成二维码",
     "securityWarning": "仅分享来自受信任 PropChain 域名的 URL",
     "ariaLabel": "房产链接二维码"
+  },
   "networkSwitcher": {
     "selectNetwork": "选择网络",
     "switchingNetwork": "正在切换网络..."
+  },
   "referral": {
     "connectWallet": "连接钱包",
     "connectWalletPrompt": "请连接您的钱包以访问推荐计划",


### PR DESCRIPTION
## Summary

Fixed missing closing braces and commas in qrCode, networkSwitcher, and referral sections across all locale files.

### Changes

- Fixed JSON structure in ar, de, en, es, fr, he, zh locale files
- Added missing closing braces and commas
- All files now parse correctly with JSON.parse
- Unblocks next build and related CI workflows

Closes #618