### PR TITLE
fix(utils): fix undeclared fields in CorrelationIdManager

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -108,7 +108,8 @@ const generateCorrelationId = (): string => genId(`corr-${Date.now().toString(36
 
 class CorrelationIdManager {
   private static instance: CorrelationIdManager;
-  private id: string = generateCorrelationId();
+  private correlationId: string = generateCorrelationId();
+  private correlationStack: string[] = [];
 
   static getInstance(): CorrelationIdManager {
     if (!CorrelationIdManager.instance) {
@@ -128,6 +129,7 @@ class CorrelationIdManager {
 
   reset(): void {
     this.correlationId = generateCorrelationId();
+    this.correlationStack = [];
   }
 
   createChild(): string {


### PR DESCRIPTION
## Summary

Fixed undeclared class fields in CorrelationIdManager that were causing runtime errors.

### Changes

- Renamed private id to correlationId to match method usage
- Added missing private correlationStack array
- Reset correlationStack on reset()

Closes #631