### PR TITLE
fix(utils): remove debug logs from production code

### DIFF
--- a/src/store/__tests__/debugSavedSearch.test.ts
+++ b/src/store/__tests__/debugSavedSearch.test.ts
@@ -3,8 +3,6 @@ import { useSavedSearchStore } from '../savedSearchStore';
 
 test('debug useSavedSearchStore shape', () => {
   const { result } = renderHook(() => useSavedSearchStore());
-  console.log('useSavedSearchStore typeof', typeof useSavedSearchStore);
-  console.log('result.current keys', Object.keys(result.current || {}));
 
   // Assert methods exist and are callable
   expect(typeof result.current.addSearch).toBe('function');

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -209,7 +209,9 @@ class Logger {
         // Structured JSON line — single console.log so log aggregators get one line
         const line = JSON.stringify(entry);
         switch (level) {
-          case LogLevel.DEBUG: console.debug(line); break;
+          case LogLevel.DEBUG:
+            if (this.config.environment === 'development') console.debug(line);
+            break;
           case LogLevel.INFO:  console.info(line);  break;
           case LogLevel.WARN:  console.warn(line);  break;
           case LogLevel.ERROR: console.error(line); break;


### PR DESCRIPTION
## Summary

Removed console.log debug statements and guarded debug output in JSON mode.

### Changes

- Removed console.log from debugSavedSearch.test.ts
- Guarded debug log output in JSON mode with environment check
- Only emit debug logs in development environment

Closes #633