### PR TITLE
fix(app): fix page.tsx duplicate properties and unused imports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,6 @@ import { ErrorCategory, ErrorSeverity } from "@/types/errors";
 import { logger } from "@/utils/logger";
 import { generateErrorId } from "@/utils/secureId";
 import { WalletConnector } from "@/components/WalletConnector";
-import { genId } from "@/utils/genId";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import {
   ChainAware,
@@ -49,7 +48,6 @@ function HomeContent() {
       error.stack = event.error?.stack;
       
       const appError = {
-        id: genId(`error_${Date.now()}`),
         id: generateErrorId(),
         category: ErrorCategory.UI,
         severity: ErrorSeverity.HIGH,
@@ -73,7 +71,6 @@ function HomeContent() {
       const error = new Error(event.reason?.message || 'Unhandled promise rejection');
       
       const appError = {
-        id: genId(`error_${Date.now()}`),
         id: generateErrorId(),
         category: ErrorCategory.NETWORK,
         severity: ErrorSeverity.MEDIUM,


### PR DESCRIPTION
## Summary

Fixed duplicate properties and removed unused imports in page.tsx.

### Changes

- Removed duplicate id properties in error objects
- Removed unused genId import
- Fixed error handling to use generateErrorId consistently

Closes #635