### PR TITLE
fix(utils): fix errorReporting dead code and unused imports

### DIFF
--- a/src/utils/errorReporting.ts
+++ b/src/utils/errorReporting.ts
@@ -1,6 +1,5 @@
 import { type AppError, ErrorCategory, ErrorSeverity, type ErrorReportingData, type ErrorMetrics } from '@/types/errors';
 import { logger } from './logger';
-import { genId } from '@/utils/genId';
 import { generateSessionId } from './secureId';
 
 class ErrorReportingService {
@@ -17,7 +16,7 @@ class ErrorReportingService {
   private retryAttempts: Map<string, number> = new Map();
 
   private constructor() {
-    this.sessionId = this.generateSessionId();
+    this.sessionId = generateSessionId();
     this.initializeMetrics();
   }
 
@@ -26,11 +25,6 @@ class ErrorReportingService {
       ErrorReportingService.instance = new ErrorReportingService();
     }
     return ErrorReportingService.instance;
-  }
-
-  private generateSessionId(): string {
-    return genId(`session_${Date.now()}`);
-    return generateSessionId();
   }
 
   private initializeMetrics(): void {


### PR DESCRIPTION
## Summary

Fixed dead code and unused imports in errorReporting.ts.

### Changes

- Removed unused genId import
- Removed redundant generateSessionId method with unreachable code
- Used generateSessionId() directly from secureId

Closes #636