### PR TITLE
feat(ui): add reusable skeleton loaders for API requests

### DIFF
--- a/src/components/ui/SkeletonLoader.tsx
+++ b/src/components/ui/SkeletonLoader.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SkeletonLoaderProps {
+  variant?: "card" | "table" | "list" | "text" | "avatar" | "image";
+  count?: number;
+  className?: string;
+}
+
+function SkeletonCard({ className }: { className?: string }) {
+  return (
+    <div className={cn("bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 space-y-4", className)}>
+      <Skeleton className="h-48 w-full rounded-lg" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+      <div className="flex gap-2">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+    </div>
+  );
+}
+
+function SkeletonTableRow({ columns = 4, className }: { columns?: number; className?: string }) {
+  return (
+    <div className={cn("flex items-center space-x-4 py-4", className)}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <Skeleton key={i} className="h-4 flex-1" />
+      ))}
+    </div>
+  );
+}
+
+function SkeletonListItem({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex items-center space-x-4 py-3", className)}>
+      <Skeleton className="h-12 w-12 rounded-full" />
+      <div className="space-y-2 flex-1">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonLoader({
+  variant = "card",
+  count = 3,
+  className,
+}: SkeletonLoaderProps) {
+  const Component = {
+    card: SkeletonCard,
+    table: SkeletonTableRow,
+    list: SkeletonListItem,
+    text: () => <Skeleton className={cn("h-4 w-full", className)} />,
+    avatar: () => <Skeleton className={cn("h-12 w-12 rounded-full", className)} />,
+    image: () => <Skeleton className={cn("h-48 w-full rounded-lg", className)} />,
+  }[variant];
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <Component key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function PropertyCardSkeleton({ className }: { className?: string }) {
+  return <SkeletonCard className={className} />;
+}
+
+export function PropertyListSkeleton({ count = 5, className }: { count?: number; className?: string }) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonListItem key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function TransactionTableSkeleton({ rows = 5, columns = 4, className }: { rows?: number; columns?: number; className?: string }) {
+  return (
+    <div className={cn("divide-y divide-gray-200 dark:divide-gray-700", className)}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <SkeletonTableRow key={i} columns={columns} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Added reusable skeleton loader components to improve perceived performance during API requests.

### Changes

- Created SkeletonLoader base component with card/table/list variants
- Created PropertyCardSkeleton for property card loading states
- Created PropertyListSkeleton for property list loading states
- Created TransactionTableSkeleton for transaction table loading states

All skeletons match final content layout and are reusable across multiple pages.

Closes #571