### PR TITLE
feat(ui): create reusable confirmation modal

### DIFF
--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
+
+interface ConfirmationModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  loading?: boolean;
+  onConfirm: () => void | Promise<void>;
+  onCancel?: () => void;
+}
+
+export function ConfirmationModal({
+  open,
+  onOpenChange,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmationModalProps) {
+  const handleConfirm = async () => {
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (error) {
+      console.error("Confirmation action failed:", error);
+    }
+  };
+
+  const handleCancel = () => {
+    onCancel?.();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            disabled={loading}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={variant === "destructive" ? "destructive" : "default"}
+            onClick={handleConfirm}
+            disabled={loading}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Processing...
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function useConfirmationModal() {
+  const [open, setOpen] = React.useState(false);
+  const [config, setConfig] = React.useState<{
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    variant?: "default" | "destructive";
+    onConfirm: () => void | Promise<void>;
+  } | null>(null);
+
+  const confirm = React.useCallback(
+    (options: {
+      title: string;
+      message: string;
+      confirmLabel?: string;
+      cancelLabel?: string;
+      variant?: "default" | "destructive";
+      onConfirm: () => void | Promise<void>;
+    }) => {
+      setConfig(options);
+      setOpen(true);
+    },
+    []
+  );
+
+  const Modal = config ? (
+    <ConfirmationModal
+      open={open}
+      onOpenChange={setOpen}
+      title={config.title}
+      message={config.message}
+      confirmLabel={config.confirmLabel}
+      cancelLabel={config.cancelLabel}
+      variant={config.variant}
+      onConfirm={config.onConfirm}
+    />
+  ) : null;
+
+  return { confirm, Modal };
+}


### PR DESCRIPTION
## Summary

Created reusable confirmation modal for destructive actions.

### Changes

- Configurable title and message
- Confirm and Cancel actions
- Loading state during confirmation
- Destructive variant styling
- useConfirmationModal hook for easy integration
- Keyboard accessible
- Closes correctly after action

Closes #573