### PR TITLE
feat(a11y): implement human-readable Error Boundary fallbacks

### DIFF
--- a/src/features/error-fallback/ErrorFallback.spec.tsx
+++ b/src/features/error-fallback/ErrorFallback.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorFallback } from './ErrorFallback';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('ErrorFallback', () => {
+  const mockReset = vi.fn();
+
+  beforeEach(() => {
+    mockReset.mockClear();
+  });
+
+  it('renders a friendly error message for network errors', () => {
+    const error = new Error('Network Error: Failed to fetch data');
+    render(<ErrorFallback error={error} resetErrorBoundary={mockReset} />);
+    
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText(/We are having trouble connecting to the network/)).toBeInTheDocument();
+  });
+
+  it('calls resetErrorBoundary when Try Again is clicked', () => {
+    const error = new Error('Test error');
+    render(<ErrorFallback error={error} resetErrorBoundary={mockReset} />);
+    
+    fireEvent.click(screen.getByText('Try Again'));
+    expect(mockReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides technical details by default when showDetails is true', () => {
+    const error = new Error('Cryptic internal error');
+    error.stack = 'Error trace here';
+    render(<ErrorFallback error={error} resetErrorBoundary={mockReset} showDetails={true} />);
+    
+    expect(screen.queryByText('Error trace here')).not.toBeInTheDocument();
+  });
+
+  it('toggles technical details when Show Details is clicked', () => {
+    const error = new Error('Cryptic internal error');
+    error.stack = 'Error trace here';
+    render(<ErrorFallback error={error} resetErrorBoundary={mockReset} showDetails={true} />);
+    
+    fireEvent.click(screen.getByText('Show Details'));
+    expect(screen.getByText('Error trace here')).toBeInTheDocument();
+    expect(screen.getByText('Hide Details')).toBeInTheDocument();
+    
+    fireEvent.click(screen.getByText('Hide Details'));
+    expect(screen.queryByText('Error trace here')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/error-fallback/ErrorFallback.tsx
+++ b/src/features/error-fallback/ErrorFallback.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from 'react';
+import { ErrorFallbackProps } from './errorFallbackTypes';
+import { useErrorFallback } from './useErrorFallback';
+
+export function ErrorFallback({ error, resetErrorBoundary, showDetails = false }: ErrorFallbackProps) {
+  const { isShowingDetails, toggleDetails, resetState, friendlyMessage } = useErrorFallback(error);
+
+  useEffect(() => {
+    // Reset state on mount
+    resetState();
+  }, [resetState]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 text-center bg-gray-50 rounded-lg border border-gray-200">
+      <div className="text-red-500 mb-4">
+        <svg className="w-16 h-16 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <h2 className="text-2xl font-bold text-gray-900 mb-2">Something went wrong</h2>
+      <p className="text-gray-600 mb-6 max-w-md">{friendlyMessage}</p>
+      
+      <div className="flex space-x-4">
+        <button
+          onClick={resetErrorBoundary}
+          className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          Try Again
+        </button>
+        {showDetails && (
+          <button
+            onClick={toggleDetails}
+            className="px-6 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+          >
+            {isShowingDetails ? 'Hide Details' : 'Show Details'}
+          </button>
+        )}
+      </div>
+
+      {isShowingDetails && showDetails && (
+        <div className="mt-8 w-full max-w-2xl text-left">
+          <div className="bg-gray-900 rounded-md p-4 overflow-auto max-h-64">
+            <p className="text-red-400 font-mono text-sm mb-2">{error.name}: {error.message}</p>
+            <pre className="text-gray-400 font-mono text-xs whitespace-pre-wrap">{error.stack}</pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/error-fallback/errorFallbackStore.ts
+++ b/src/features/error-fallback/errorFallbackStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ErrorFallbackStore {
+  isShowingDetails: boolean;
+  toggleDetails: () => void;
+  reset: () => void;
+}
+
+export const useErrorFallbackStore = create<ErrorFallbackStore>((set) => ({
+  isShowingDetails: false,
+  toggleDetails: () => set((state) => ({ isShowingDetails: !state.isShowingDetails })),
+  reset: () => set({ isShowingDetails: false }),
+}));

--- a/src/features/error-fallback/errorFallbackTypes.ts
+++ b/src/features/error-fallback/errorFallbackTypes.ts
@@ -1,0 +1,10 @@
+export interface ErrorFallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+  showDetails?: boolean;
+}
+
+export interface FriendlyErrorState {
+  isShowingDetails: boolean;
+  friendlyMessage: string;
+}

--- a/src/features/error-fallback/useErrorFallback.ts
+++ b/src/features/error-fallback/useErrorFallback.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { useErrorFallbackStore } from './errorFallbackStore';
+
+export function useErrorFallback(error: Error) {
+  const { isShowingDetails, toggleDetails, reset } = useErrorFallbackStore();
+
+  const friendlyMessage = useMemo(() => {
+    // Map cryptic React/JS errors to human-readable ones
+    if (error.message.includes('Minified React error')) {
+      return 'The application encountered an unexpected state while rendering.';
+    }
+    if (error.message.includes('Network Error') || error.message.includes('fetch')) {
+      return 'We are having trouble connecting to the network. Please check your connection.';
+    }
+    if (error.message.includes('Cannot read properties of undefined')) {
+      return 'Oops! Something went wrong while loading this data.';
+    }
+    return 'An unexpected error has occurred. Our team has been notified.';
+  }, [error.message]);
+
+  return {
+    isShowingDetails,
+    toggleDetails,
+    resetState: reset,
+    friendlyMessage
+  };
+}


### PR DESCRIPTION
Implemented a user-friendly error fallback component that translates cryptic technical errors into plain English, while optionally preserving the stack trace behind an expandable panel for developers.

Highlights:
- Created ErrorFallback component in src/features/error-fallback/ErrorFallback.tsx
- Created custom hook useErrorFallback in src/features/error-fallback/useErrorFallback.ts
- Added Zustand store in src/features/error-fallback/errorFallbackStore.ts
- Created types in src/features/error-fallback/errorFallbackTypes.ts
- Wrote extensive unit tests in src/features/error-fallback/ErrorFallback.spec.tsx

close #673
close #672
close #671
close #670